### PR TITLE
#53 Adding multi line hint texts to the nino page

### DIFF
--- a/app/views/components/input_text.scala.html
+++ b/app/views/components/input_text.scala.html
@@ -20,15 +20,19 @@
 viewModel: InputViewModelBase,
 label: String,
 inputClass: Option[String] = None,
-hint: Option[String] = None,
+hintLine1: Option[String] = None,
+hintLine2: Option[String] = None,
 labelClass: Option[String] = None
 )(implicit messages: Messages)
 
 <div class="form-field @if(viewModel.errorKey.nonEmpty){form-field--error}">
     <label class="form-label" for="@{viewModel.id}">
         <span class="bold @if(labelClass.nonEmpty){@labelClass}">@label</span>
-        @if(hint.nonEmpty){
-        <span class="form-hint">@hint</span>
+        @if(hintLine1.nonEmpty){
+        <span class="form-hint">@hintLine1</span>
+        }
+        @if(hintLine2.nonEmpty){
+        <span id="hint-line-2" class="form-hint">@hintLine2</span>
         }
         @if(viewModel.errorKey.nonEmpty){
         <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>

--- a/app/views/nationalInsuranceNumber.scala.html
+++ b/app/views/nationalInsuranceNumber.scala.html
@@ -35,7 +35,7 @@
 
         @components.heading("nationalInsuranceNumber.heading")
 
-        @components.input_text(InputViewModel("value", form), label = messages("nationalInsuranceNumber.heading"), labelClass=Some("visually-hidden"))
+        @components.input_text(InputViewModel("value", form), label = messages("nationalInsuranceNumber.heading"), labelClass=Some("visually-hidden"), hintLine1 = Some(messages("nationalInsuranceNumber.hintLine1")), hintLine2 = Some(messages("nationalInsuranceNumber.hintLine2")))
 
         @components.submit_button()
     }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -99,6 +99,8 @@ fullName.tooLong = Enter a valid full name
 nationalInsuranceNumber.title = Enter your National insurance number
 nationalInsuranceNumber.heading = What is your National Insurance number?
 nationalInsuranceNumber.checkYourAnswersLabel = Your National insurance number
+nationalInsuranceNumber.hintLine1 = It''s on your National Insurance card, benefit letter, payslip or P60.
+nationalInsuranceNumber.hintLine2 = For example, ''QQ 12 34 56 C''
 nationalInsuranceNumber.blank = Enter your National Insurance number
 nationalInsuranceNumber.invalid = Enter a valid National Insurance number
 

--- a/test/views/NationalInsuranceNumberViewSpec.scala
+++ b/test/views/NationalInsuranceNumberViewSpec.scala
@@ -38,6 +38,7 @@ class NationalInsuranceNumberViewSpec extends StringViewBehaviours {
 
     behave like pageWithBackLink(createView)
 
-    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.NationalInsuranceNumberController.onSubmit(NormalMode).url)
+    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.NationalInsuranceNumberController.onSubmit(NormalMode).url,
+      Some(s"$messageKeyPrefix.hintLine1"), Some(s"$messageKeyPrefix.hintLine2"))
   }
 }

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -65,15 +65,21 @@ trait ViewSpecBase extends SpecBase {
     assert(doc.select(cssSelector).isEmpty, "\n\nElement " + cssSelector + " was rendered on the page.\n")
   }
 
-  def assertContainsLabel(doc: Document, forElement: String, expectedText: String, expectedHintText: Option[String] = None) = {
+  def assertContainsLabel(doc: Document, forElement: String, expectedText: String, expectedHintTextLine1: Option[String] = None,
+                          expectedHintTextLine2: Option[String] = None) = {
     val labels = doc.getElementsByAttributeValue("for", forElement)
     assert(labels.size == 1, s"\n\nLabel for $forElement was not rendered on the page.")
     val label = labels.first
     assert(label.child(0).text == expectedText, s"\n\nLabel for $forElement was not $expectedText")
 
-    if (expectedHintText.isDefined) {
-      assert(label.getElementsByClass("form-hint").first.text == expectedHintText.get,
-        s"\n\nLabel for $forElement did not contain hint text $expectedHintText")
+    if (expectedHintTextLine1.isDefined) {
+      assert(label.getElementsByClass("form-hint").first.text == expectedHintTextLine1.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine1")
+    }
+
+    if (expectedHintTextLine2.isDefined) {
+      assert(label.getElementById("hint-line-2").text == expectedHintTextLine2.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine2")
     }
   }
 

--- a/test/views/behaviours/StringViewBehaviours.scala
+++ b/test/views/behaviours/StringViewBehaviours.scala
@@ -26,16 +26,18 @@ trait StringViewBehaviours extends QuestionViewBehaviours[String] {
   def stringPage(createView: (Form[String]) => HtmlFormat.Appendable,
                  messageKeyPrefix: String,
                  expectedFormAction: String,
-                 expectedHintKey: Option[String] = None) = {
+                 expectedHintKeyLine1: Option[String] = None,
+                 expectedHintKeyLine2: Option[String] = None) = {
 
     "behave like a page with a string value field" when {
       "rendered" must {
 
         "contain a label for the value" in {
           val doc = asDocument(createView(form))
-          val expectedHintText = expectedHintKey map(k => messages(k))
-          assertContainsLabel(doc, "value", messages(s"$messageKeyPrefix.heading"), expectedHintText)
-        }
+          val expectedHintTextLine1 = expectedHintKeyLine1 map(k => messages(k))
+          val expectedHintTextLine2 = expectedHintKeyLine2 map(k => messages(k))
+          assertContainsLabel(doc, "value", messages(s"$messageKeyPrefix.heading"), expectedHintTextLine1, expectedHintTextLine2)
+      }
 
         "contain an input for the value" in {
           val doc = asDocument(createView(form))


### PR DESCRIPTION
### Description
Adding the hint text to the national insurance number page as per the Government Design pattern

### Issue link
#53 

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [ ] Used TDD to develop the changes
- [x] Not reduced code coverage unnecessarily or below acceptable threshold (run sbt scoverage to check)
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked
