### PR TITLE
Updating UK address pages to use regex

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -47,7 +47,7 @@ class FrontendAppConfig @Inject() (override val configuration: Configuration) ex
   lazy val fullNameLength = loadConfigInt("microservice.services.validation.full-name-length")
   lazy val ninoRegex = loadConfig("microservice.services.validation.nino-regex")
   lazy val addressLineMaxLength = loadConfigInt("microservice.services.validation.address-line-length")
-  lazy val postcodeMaxLength = loadConfigInt("microservice.services.validation.postcode-length")
+  lazy val postcodeRegex = loadConfig("microservice.services.validation.postcode-regex")
   lazy val countryMaxLength = loadConfigInt("microservice.services.validation.country-length")
 
   lazy val telephoneRegex = loadConfig("microservice.services.validation.telephone-regex")

--- a/app/forms/UkAddressForm.scala
+++ b/app/forms/UkAddressForm.scala
@@ -25,7 +25,7 @@ import play.api.data.Forms.{mapping, optional, text}
 class UkAddressForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHelper with Constraints {
 
   private val maxLengthInt = appConfig.addressLineMaxLength
-  private val postcodeMaxLength = appConfig.postcodeMaxLength
+  private val postcodeRegex = appConfig.postcodeRegex
 
   private val addressLine1KeyBlank = "global.addressLine1.blank"
   private val addressLine1KeyTooLong = "global.addressLine1.tooLong"
@@ -34,8 +34,7 @@ class UkAddressForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHe
   private val addressLine3KeyTooLong = "global.addressLine3.tooLong"
   private val addressLine4KeyTooLong = "global.addressLine4.tooLong"
   private val addressLine5KeyTooLong = "global.addressLine5.tooLong"
-  private val postcodeKeyBlank = "global.postcode.blank"
-  private val postcodeTooLong = "global.postcode.tooLong"
+  private val postcodeKeyInvalid = "ukAddress.postcode.invalid"
 
   def apply(): Form[UkAddress] = {
     Form(
@@ -45,7 +44,7 @@ class UkAddressForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHe
         "addressLine3" -> optional(text.verifying(maxLength(maxLengthInt, addressLine3KeyTooLong))),
         "addressLine4" -> optional(text.verifying(maxLength(maxLengthInt, addressLine4KeyTooLong))),
         "addressLine5" -> optional(text.verifying(maxLength(maxLengthInt, addressLine5KeyTooLong))),
-        "postcode"      -> text.verifying(nonEmpty(postcodeKeyBlank), maxLength(postcodeMaxLength, postcodeTooLong))
+        "postcode"     -> text.verifying(regexValidation(postcodeRegex, postcodeKeyInvalid))
       )(UkAddress.apply)(UkAddress.unapply))
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,7 +92,7 @@ microservice {
         full-name-length = 30
         telephone-regex = """^\+?[0-9\s\(\)]{1,20}$"""
         address-line-length = 35
-        postcode-length = 10
+        postcode-regex = """([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})"""
         country-length = 35
       }
     }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -113,7 +113,6 @@ ukAddress.title = What is your address?
 ukAddress.heading = What is your address?
 ukAddress.checkYourAnswersLabel = Your address
 ukAddress.postcode.invalid = Enter a valid postcode
-ukAddress.postcode.blank = Enter your postcode
 
 internationalAddress.title = What is your address?
 internationalAddress.heading = What is your address?

--- a/test/controllers/UkAddressControllerSpec.scala
+++ b/test/controllers/UkAddressControllerSpec.scala
@@ -54,17 +54,17 @@ class UkAddressControllerSpec extends ControllerSpecBase {
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
-      val validData = Map(UkAddressId.toString -> Json.toJson(UkAddress("line 1", "line 2", None, None, None, "postcode")))
+      val validData = Map(UkAddressId.toString -> Json.toJson(UkAddress("line 1", "line 2", None, None, None, "NE1 7RF")))
       val getRelevantData = new FakeDataRetrievalAction(Some(CacheMap(cacheMapId, validData)))
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
       contentAsString(result) mustBe viewAsString(form
-        .fill(UkAddress("line 1", "line 2", None, None, None, "postcode")))
+        .fill(UkAddress("line 1", "line 2", None, None, None, "NE1 7RF")))
     }
 
     "redirect to the next page when valid data is submitted" in {
-      val postRequest = fakeRequest.withFormUrlEncodedBody(("addressLine1", "line 1"),("addressLine2", "line 2") , ("postcode", "postcode"))
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("addressLine1", "line 1"),("addressLine2", "line 2") , ("postcode", "NE2 7RF"))
 
       val result = controller().onSubmit(NormalMode)(postRequest)
 
@@ -90,7 +90,7 @@ class UkAddressControllerSpec extends ControllerSpecBase {
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
-      val postRequest = fakeRequest.withFormUrlEncodedBody(("addressLine1", "line 1"), ("addressLine2", "line 2"), ("postcode", "postcode"))
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("addressLine1", "line 1"), ("addressLine2", "line 2"), ("postcode", "NE1 6RF"))
       val result = controller(dontGetAnyData).onSubmit(NormalMode)(postRequest)
 
       status(result) mustBe SEE_OTHER

--- a/test/forms/UkAddressFormSpec.scala
+++ b/test/forms/UkAddressFormSpec.scala
@@ -26,12 +26,12 @@ import play.api.data.Form
 class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
 
   val addressLineMaxLength = 35
-  val postcodeMaxLength = 10
+  val postcodeRegex = """([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})"""
 
   def appConfig: FrontendAppConfig = {
     val instance = mock[FrontendAppConfig]
     when(instance.addressLineMaxLength) thenReturn addressLineMaxLength
-    when(instance.postcodeMaxLength) thenReturn postcodeMaxLength
+    when(instance.postcodeRegex) thenReturn postcodeRegex
     instance
   }
 
@@ -42,8 +42,7 @@ class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
   val addressLine3TooLong = "global.addressLine3.tooLong"
   val addressLine4TooLong = "global.addressLine4.tooLong"
   val addressLine5TooLong = "global.addressLine5.tooLong"
-  val postcodeBlank = "global.postcode.blank"
-  val postcodeTooLong = "global.postcode.tooLong"
+  val postcodeInvalid = "ukAddress.postcode.invalid"
 
   val validData: Map[String, String] = Map(
     "addressLine1" -> "line 1",
@@ -51,18 +50,18 @@ class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
     "addressLine3" -> "line 3",
     "addressLine4" -> "line 4",
     "addressLine5" -> "line 5",
-    "postcode" -> "postcode"
+    "postcode" -> "NE1 7RF"
   )
 
   override val form: Form[_] = new UkAddressForm(appConfig)()
 
   "UkAddress form" must {
-    behave like questionForm(UkAddress("line 1", "line 2", Some("line 3"), Some("line 4"), Some("line 5"), "postcode"))
+    behave like questionForm(UkAddress("line 1", "line 2", Some("line 3"), Some("line 4"), Some("line 5"), "NE1 7RF"))
 
     behave like formWithMandatoryTextFieldsAndCustomKey(
       ("addressLine1", addressLine1Blank),
       ("addressLine2", addressLine2Blank),
-      ("postcode", postcodeBlank))
+      ("postcode", postcodeInvalid))
 
     behave like formWithOptionalTextFields("addressLine3", "addressLine4", "addressLine5")
 
@@ -71,7 +70,6 @@ class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
       MaxLengthField("addressLine2", addressLine2TooLong, addressLineMaxLength),
       MaxLengthField("addressLine3", addressLine3TooLong, addressLineMaxLength),
       MaxLengthField("addressLine4", addressLine4TooLong, addressLineMaxLength),
-      MaxLengthField("addressLine5", addressLine5TooLong, addressLineMaxLength),
-      MaxLengthField("postcode", postcodeTooLong , postcodeMaxLength))
+      MaxLengthField("addressLine5", addressLine5TooLong, addressLineMaxLength))
   }
 }


### PR DESCRIPTION
### Description
Updates the current postcode validation to use the government standard regex validation rather than max lengths

### Issue
#52 

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [x] Used TDD to develop the changes
- [x] Not reduced code coverage unnecessarily or below acceptable threshold (run sbt scoverage to check)
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked
