### PR TITLE
Implementing national insurance regex validation

### DIFF
--- a/app/controllers/NationalInsuranceNumberController.scala
+++ b/app/controllers/NationalInsuranceNumberController.scala
@@ -39,20 +39,23 @@ class NationalInsuranceNumberController @Inject()(
                                         navigator: Navigator,
                                         authenticate: AuthAction,
                                         getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction) extends FrontendController with I18nSupport {
+                                        requireData: DataRequiredAction,
+                                        formBuilder: NationalInsuranceNumberForm) extends FrontendController with I18nSupport {
+
+  private val form: Form[String] = formBuilder()
 
   def onPageLoad(mode: Mode) = (authenticate andThen getData andThen requireData) {
     implicit request =>
       val preparedForm = request.userAnswers.nationalInsuranceNumber match {
-        case None => NationalInsuranceNumberForm(appConfig.ninoRegex)
-        case Some(value) => NationalInsuranceNumberForm(appConfig.ninoRegex).fill(value)
+        case None => form
+        case Some(value) => form.fill(value)
       }
       Ok(nationalInsuranceNumber(appConfig, preparedForm, mode))
   }
 
   def onSubmit(mode: Mode) = (authenticate andThen getData andThen requireData).async {
     implicit request =>
-      NationalInsuranceNumberForm(appConfig.ninoRegex).bindFromRequest().fold(
+      form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
           Future.successful(BadRequest(nationalInsuranceNumber(appConfig, formWithErrors, mode))),
         (value) =>

--- a/app/forms/NationalInsuranceNumberForm.scala
+++ b/app/forms/NationalInsuranceNumberForm.scala
@@ -16,29 +16,18 @@
 
 package forms
 
+import com.google.inject.Inject
+import config.FrontendAppConfig
 import play.api.data.{Form, FormError}
 import play.api.data.Forms._
 import play.api.data.format.Formatter
 
-object NationalInsuranceNumberForm extends FormErrorHelper {
+class NationalInsuranceNumberForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHelper with Constraints {
 
-  def nationalInsuranceNumberFormatter(regex: String) = new Formatter[String] {
+  private val nationalNumberRegex = appConfig.ninoRegex
+  private val errorKeyInvalid = "nationalInsuranceNumber.invalid"
 
-    val errorKeyBlank = "nationalInsuranceNumber.blank"
-    val errorKeyInvalid = "nationalInsuranceNumber.invalid"
-
-    def bind(key: String, data: Map[String, String]) = {
-      data.get(key) match {
-        case None => produceError(key, errorKeyBlank)
-        case Some("") => produceError(key, errorKeyBlank)
-        case Some(s) if !s.matches(regex) => produceError(key, errorKeyInvalid)
-        case Some(s) => Right(s)
-      }
-    }
-
-    def unbind(key: String, value: String) = Map(key -> value)
-  }
-
-  def apply(regex: String):
-  Form[String] = Form(single("value" -> of(nationalInsuranceNumberFormatter(regex))))
+  def apply(): Form[String] = Form(
+    "value" -> text.verifying(regexValidation(nationalNumberRegex, errorKeyInvalid))
+  )
 }

--- a/test/controllers/NationalInsuranceNumberControllerSpec.scala
+++ b/test/controllers/NationalInsuranceNumberControllerSpec.scala
@@ -31,18 +31,18 @@ import views.html.nationalInsuranceNumber
 class NationalInsuranceNumberControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.IsTheAddressInTheUKController.onPageLoad(NormalMode)
-  val testRegex = """^((?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\d){6}([A-D]|\s)?)|(\d{2})([a-zA-Z])(\d{5})([a-zA-Z])$"""
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new NationalInsuranceNumberController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction,
-      dataRetrievalAction, new DataRequiredActionImpl)
+      dataRetrievalAction, new DataRequiredActionImpl, new NationalInsuranceNumberForm(frontendAppConfig))
 
-  private val defaultForm = NationalInsuranceNumberForm(testRegex)
+  private val testAnswer = "AB123456A"
+  private val testRegex = """^((?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\d){6}([A-D]|\s)?)|(\d{2})([a-zA-Z])(\d{5})([a-zA-Z])$"""
 
-  def viewAsString(form: Form[_] = defaultForm) =
+  val form = new NationalInsuranceNumberForm(frontendAppConfig)()
+
+  def viewAsString(form: Form[_] = form) =
     nationalInsuranceNumber(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
-
-  val testAnswer = "AB123456A"
 
   "NationalInsuranceNumber Controller" must {
 
@@ -59,7 +59,7 @@ class NationalInsuranceNumberControllerSpec extends ControllerSpecBase {
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
-      contentAsString(result) mustBe viewAsString(defaultForm.fill(testAnswer))
+      contentAsString(result) mustBe viewAsString(form.fill(testAnswer))
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -73,7 +73,7 @@ class NationalInsuranceNumberControllerSpec extends ControllerSpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid"))
-      val boundForm = defaultForm.bind(Map("value" -> "invalid"))
+      val boundForm = form.bind(Map("value" -> "invalid"))
 
       val result = controller().onSubmit(NormalMode)(postRequest)
 

--- a/test/forms/NationalInsuranceNumberFormSpec.scala
+++ b/test/forms/NationalInsuranceNumberFormSpec.scala
@@ -16,38 +16,31 @@
 
 package forms
 
-class NationalInsuranceNumberFormSpec extends FormSpec {
+import config.FrontendAppConfig
+import forms.behaviours.FormBehaviours
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import play.api.data.Form
 
-  val errorKeyBlank = "nationalInsuranceNumber.blank"
-  val errorKeyInvalid = "nationalInsuranceNumber.invalid"
-  val testRegex = """^((?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\d){6}([A-D]|\s)?)|(\d{2})([a-zA-Z])(\d{5})([a-zA-Z])$"""
+class NationalInsuranceNumberFormSpec extends FormBehaviours with MockitoSugar {
+
+  private val errorKeyInvalid = "nationalInsuranceNumber.invalid"
+  private val testRegex = """^((?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\d){6}([A-D]|\s)?)|(\d{2})([a-zA-Z])(\d{5})([a-zA-Z])$"""
+
+  def appConfig: FrontendAppConfig = {
+    val instance = mock[FrontendAppConfig]
+    when(instance.ninoRegex) thenReturn testRegex
+    instance
+  }
+
+  val validData: Map[String, String] = Map("value" -> "AB123456A")
+
+  override val form: Form[_] = new NationalInsuranceNumberForm(appConfig)()
 
   "NationalInsuranceNumber Form" must {
 
-    "bind a string when the standard national insurance number is valid" in {
-      val validNino = "AB123456A"
-      val form = NationalInsuranceNumberForm(testRegex).bind(Map("value" -> validNino))
-      form.get shouldBe "AB123456A"
-    }
+    behave like questionForm("AB123456A")
 
-    "bind a string when the temporary national insurance number is valid" in {
-      val form = NationalInsuranceNumberForm(testRegex).bind(Map("value" -> "89A12345A"))
-      form.get shouldBe "89A12345A"
-    }
-
-    "fail to bind an invalid national insurance number" in {
-      val expectedError = error("value", errorKeyInvalid)
-      checkForError(NationalInsuranceNumberForm(testRegex), Map("value" -> "invalid"), expectedError)
-    }
-
-    "fail to bind a blank value" in {
-      val expectedError = error("value", errorKeyBlank)
-      checkForError(NationalInsuranceNumberForm(testRegex), Map("value" -> ""), expectedError)
-    }
-
-    "fail to bind when value is omitted" in {
-      val expectedError = error("value", errorKeyBlank)
-      checkForError(NationalInsuranceNumberForm(testRegex), emptyForm, expectedError)
-    }
+    behave like formWithMandatoryTextFieldsAndCustomKey(("value", errorKeyInvalid))
   }
 }

--- a/test/views/NationalInsuranceNumberViewSpec.scala
+++ b/test/views/NationalInsuranceNumberViewSpec.scala
@@ -16,18 +16,23 @@
 
 package views
 
+import config.FrontendAppConfig
 import play.api.data.Form
 import controllers.routes
 import forms.NationalInsuranceNumberForm
 import models.NormalMode
+import org.scalatest.mockito.MockitoSugar
 import views.behaviours.StringViewBehaviours
 import views.html.nationalInsuranceNumber
 
-class NationalInsuranceNumberViewSpec extends StringViewBehaviours {
+class NationalInsuranceNumberViewSpec extends StringViewBehaviours with MockitoSugar{
 
   val messageKeyPrefix = "nationalInsuranceNumber"
   val testRegex = """^((?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\d){6}([A-D]|\s)?)|(\d{2})([a-zA-Z])(\d{5})([a-zA-Z])$"""
-  val form = NationalInsuranceNumberForm(testRegex)
+
+  private val appConfig: FrontendAppConfig = mock[FrontendAppConfig]
+
+  override val form: Form[String] = new NationalInsuranceNumberForm(appConfig)()
 
   def createView = () => nationalInsuranceNumber(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 


### PR DESCRIPTION
### Description
Implementing regex validation on the national insurance number rather than using max lengths and blanks

### Issue
#52 

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [x] Not reduced code coverage unnecessarily or below acceptable threshold (run sbt scoverage to check)
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked
