### PR TITLE
Moving scaffolds to use new mandatory text field form behaviour

### DIFF
--- a/.g8/questionPage/generated-test/forms/$className$FormSpec.scala
+++ b/.g8/questionPage/generated-test/forms/$className$FormSpec.scala
@@ -2,7 +2,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.$className$
+import models.{$className$, MandatoryField}
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import org.mockito.Mockito._
@@ -14,6 +14,9 @@ class $className$FormSpec extends FormBehaviours with MockitoSugar {
     instance
   }
 
+  private val field1ErrorKeyBlank = "error.required"
+  private val field2ErrorKeyBlank = "error.required"
+
   val validData: Map[String, String] = Map(
     "field1" -> "value 1",
     "field2" -> "value 2"
@@ -24,6 +27,9 @@ class $className$FormSpec extends FormBehaviours with MockitoSugar {
   "$className$ form" must {
     behave like questionForm($className$("value 1", "value 2"))
 
-    behave like formWithMandatoryTextFields("field1", "field2")
+    behave like formWithMandatoryTextFields(
+      MandatoryField("field1", field1ErrorKeyBlank),
+      MandatoryField("field2", field2ErrorKeyBlank)
+    )
   }
 }

--- a/.g8/stringPage/generated-test/forms/$className$FormSpec.scala
+++ b/.g8/stringPage/generated-test/forms/$className$FormSpec.scala
@@ -2,7 +2,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.MaxLengthField
+import models.MandatoryField
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import play.api.data.Form
@@ -22,6 +22,8 @@ class $className$FormSpec extends FormBehaviours with MockitoSugar {
 
   "$className$ Form" must {
 
-    behave like formWithMandatoryTextFieldsAndCustomKey(("value", errorKeyBlank))
+    behave like formWithMandatoryTextFields(
+      MandatoryField("value", errorKeyBlank)
+    )
   }
 }


### PR DESCRIPTION
### Description
This moves the g8Scaffolds to use the refactored form behaviour test with mandatory field case class

### Issue
#55 

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [x] Not reduced code coverage unnecessarily or below acceptable threshold (run sbt scoverage to check)
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Created test scaffolds to ensure the scaffolds compile and work as expected
