### PR TITLE
behaviour test for regex

### DIFF
--- a/app/forms/NationalInsuranceNumberForm.scala
+++ b/app/forms/NationalInsuranceNumberForm.scala
@@ -26,8 +26,9 @@ class NationalInsuranceNumberForm @Inject() (appConfig: FrontendAppConfig) exten
 
   private val nationalNumberRegex = appConfig.ninoRegex
   private val errorKeyInvalid = "nationalInsuranceNumber.invalid"
+  private val errorKeyBlank = "nationalInsuranceNumber.blank"
 
   def apply(): Form[String] = Form(
-    "value" -> text.verifying(regexValidation(nationalNumberRegex, errorKeyInvalid))
+    "value" -> text.verifying(firstError(nonEmpty(errorKeyBlank), regexValidation(nationalNumberRegex, errorKeyInvalid)))
   )
 }

--- a/app/forms/PayAsYouEarnForm.scala
+++ b/app/forms/PayAsYouEarnForm.scala
@@ -25,8 +25,9 @@ class PayAsYouEarnForm @Inject() (appConfig: FrontendAppConfig) extends FormErro
 
   private val payeRegex = appConfig.payeRegex
   private val errorKeyInvalid = "payAsYouEarn.invalid"
+  private val errorKeyBlank = "payAsYouEarn.blank"
 
   def apply(): Form[String] = Form(
-    "value" -> text.verifying(regexValidation(payeRegex, errorKeyInvalid))
+    "value" -> text.verifying(firstError(nonEmpty(errorKeyBlank), regexValidation(payeRegex, errorKeyInvalid)))
   )
 }

--- a/app/forms/TelephoneNumberForm.scala
+++ b/app/forms/TelephoneNumberForm.scala
@@ -26,8 +26,9 @@ class TelephoneNumberForm @Inject() (appConfig: FrontendAppConfig) extends FormE
 
   private val telephoneRegex = appConfig.telephoneRegex
   private val errorKeyInvalid = "telephoneNumber.invalid"
+  private val errorKeyBlank = "telephoneNumber.blank"
 
   def apply(): Form[String] = Form(
-    "value" -> text.verifying(regexValidation(telephoneRegex, errorKeyInvalid))
+    "value" -> text.verifying(firstError(nonEmpty(errorKeyBlank), regexValidation(telephoneRegex, errorKeyInvalid)))
   )
 }

--- a/app/forms/UkAddressForm.scala
+++ b/app/forms/UkAddressForm.scala
@@ -35,6 +35,7 @@ class UkAddressForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHe
   private val addressLine4KeyTooLong = "global.addressLine4.tooLong"
   private val addressLine5KeyTooLong = "global.addressLine5.tooLong"
   private val postcodeKeyInvalid = "ukAddress.postcode.invalid"
+  private val postcodeKeyBlank = "ukAddress.postcode.blank"
 
   def apply(): Form[UkAddress] = {
     Form(
@@ -44,7 +45,7 @@ class UkAddressForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHe
         "addressLine3" -> optional(text.verifying(maxLength(maxLengthInt, addressLine3KeyTooLong))),
         "addressLine4" -> optional(text.verifying(maxLength(maxLengthInt, addressLine4KeyTooLong))),
         "addressLine5" -> optional(text.verifying(maxLength(maxLengthInt, addressLine5KeyTooLong))),
-        "postcode"     -> text.verifying(regexValidation(postcodeRegex, postcodeKeyInvalid))
+        "postcode"     -> text.verifying(firstError(nonEmpty(postcodeKeyBlank), regexValidation(postcodeRegex, postcodeKeyInvalid)))
       )(UkAddress.apply)(UkAddress.unapply))
   }
 }

--- a/app/forms/UniqueTaxpayerReferenceForm.scala
+++ b/app/forms/UniqueTaxpayerReferenceForm.scala
@@ -26,8 +26,9 @@ class UniqueTaxpayerReferenceForm @Inject() (appConfig: FrontendAppConfig) exten
 
   private val utrRegex = appConfig.utrRegex
   private val errorKeyInvalid = "uniqueTaxpayerReference.invalid"
+  private val errorKeyBlank = "uniqueTaxpayerReference.blank"
 
   def apply(): Form[String] = Form(
-    "value" -> text.verifying(regexValidation(utrRegex, errorKeyInvalid))
+    "value" -> text.verifying(firstError(nonEmpty(errorKeyBlank), regexValidation(utrRegex, errorKeyInvalid)))
   )
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -115,6 +115,7 @@ ukAddress.title = What is your address?
 ukAddress.heading = What is your address?
 ukAddress.checkYourAnswersLabel = Your address
 ukAddress.postcode.invalid = Enter a valid postcode
+ukAddress.postcode.blank = Enter a postcode
 
 internationalAddress.title = What is your address?
 internationalAddress.heading = What is your address?
@@ -126,6 +127,7 @@ telephoneNumber.title = What is your telephone number?
 telephoneNumber.heading = What is your telephone number?
 telephoneNumber.checkYourAnswersLabel = Your telephone number
 telephoneNumber.invalid = Enter a valid telephone number
+telephoneNumber.blank = Enter a telephone number
 
 typeOfClaim.title = What kind of tax refund do you want to claim?
 typeOfClaim.heading = What kind of tax refund do you want to claim?
@@ -138,6 +140,7 @@ uniqueTaxpayerReference.title = What is your Unique Taxpayer Reference number?
 uniqueTaxpayerReference.heading = What is your Unique Taxpayer Reference number?
 uniqueTaxpayerReference.checkYourAnswersLabel = Your Unique Taxpayer Reference number
 uniqueTaxpayerReference.invalid = Enter a valid Unique Taxpayer Reference number
+uniqueTaxpayerReference.blank = Enter a Unique Taxpayer Reference number
 uniqueTaxpayerReference.hintLine1 = This is a 10 digit number, like 1234567890.
 uniqueTaxpayerReference.hintLine2 = You can find this on your tax return, statement of accounts or any other self-assessment calculations.
 

--- a/test/forms/NationalInsuranceNumberFormSpec.scala
+++ b/test/forms/NationalInsuranceNumberFormSpec.scala
@@ -18,7 +18,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.MandatoryField
+import models.{MandatoryField, RegexField}
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -26,6 +26,7 @@ import play.api.data.Form
 class NationalInsuranceNumberFormSpec extends FormBehaviours with MockitoSugar {
 
   private val errorKeyInvalid = "nationalInsuranceNumber.invalid"
+  private val errorKeyBlank = "nationalInsuranceNumber.blank"
   private val testRegex = """^((?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\d){6}([A-D]|\s)?)|(\d{2})([a-zA-Z])(\d{5})([a-zA-Z])$"""
 
   def appConfig: FrontendAppConfig = {
@@ -42,6 +43,8 @@ class NationalInsuranceNumberFormSpec extends FormBehaviours with MockitoSugar {
 
     behave like questionForm("AB123456A")
 
-    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyInvalid))
+    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyBlank))
+
+    behave like formWithRegex(RegexField("value", errorKeyInvalid, testRegex))
   }
 }

--- a/test/forms/PartialClaimAmountFormSpec.scala
+++ b/test/forms/PartialClaimAmountFormSpec.scala
@@ -18,7 +18,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.MandatoryField
+import models.{MandatoryField, RegexField}
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import play.api.data.Form
@@ -27,6 +27,7 @@ class PartialClaimAmountFormSpec extends FormBehaviours with MockitoSugar {
 
   private val testRegex = """(?=.)^\$?(([1-9][0-9]{0,2}(,[0-9]{3})*)|[0-9]+)?(\.[0-9]{1,2})?$"""
   private val errorKeyInvalid = "partialClaimAmount.invalid"
+  private val errorKeyBlank = "partialClaimAmount.blank"
 
   def appConfig: FrontendAppConfig = {
     val instance = mock[FrontendAppConfig]
@@ -42,6 +43,8 @@ class PartialClaimAmountFormSpec extends FormBehaviours with MockitoSugar {
 
     behave like questionForm("""9,999.99""")
 
-    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyInvalid))
+    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyBlank))
+
+    behave like formWithRegex(RegexField("value", errorKeyInvalid, testRegex))
   }
 }

--- a/test/forms/PayAsYouEarnFormSpec.scala
+++ b/test/forms/PayAsYouEarnFormSpec.scala
@@ -18,7 +18,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.{MandatoryField, MaxLengthField}
+import models.{MandatoryField, MaxLengthField, RegexField}
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import play.api.data.Form
@@ -27,6 +27,7 @@ class PayAsYouEarnFormSpec extends FormBehaviours with MockitoSugar {
 
   private val testRegex = """^[0-9]{3}\/[A-Z]{1,2}[0-9]{0,8}$"""
   private val errorKeyInvalid = "payAsYouEarn.invalid"
+  private val errorKeyBlank = "payAsYouEarn.blank"
 
   def appConfig: FrontendAppConfig = {
     val instance = mock[FrontendAppConfig]
@@ -42,6 +43,8 @@ class PayAsYouEarnFormSpec extends FormBehaviours with MockitoSugar {
 
     behave like questionForm("""123/AB123""")
 
-    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyInvalid))
+    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyBlank))
+
+    behave like formWithRegex(RegexField("value", errorKeyInvalid, testRegex))
   }
 }

--- a/test/forms/TelephoneNumberFormSpec.scala
+++ b/test/forms/TelephoneNumberFormSpec.scala
@@ -18,7 +18,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.{MandatoryField, MaxLengthField}
+import models.{MandatoryField, MaxLengthField, RegexField}
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import play.api.data.Form
@@ -26,6 +26,7 @@ import play.api.data.Form
 class TelephoneNumberFormSpec extends FormBehaviours with MockitoSugar {
 
   private val errorKeyInvalid = "telephoneNumber.invalid"
+  private val errorKeyBlank = "telephoneNumber.blank"
   private val testRegex = """^\+?[0-9\s\(\)]{1,20}$"""
 
   def appConfig: FrontendAppConfig = {
@@ -42,6 +43,8 @@ class TelephoneNumberFormSpec extends FormBehaviours with MockitoSugar {
 
     behave like questionForm("01963 123456")
 
-    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyInvalid))
+    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyBlank))
+
+    behave like formWithRegex(RegexField("value", errorKeyInvalid, testRegex))
   }
 }

--- a/test/forms/UkAddressFormSpec.scala
+++ b/test/forms/UkAddressFormSpec.scala
@@ -18,7 +18,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.{MandatoryField, MaxLengthField, UkAddress}
+import models.{MandatoryField, MaxLengthField, RegexField, UkAddress}
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -43,6 +43,7 @@ class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
   val addressLine4TooLong = "global.addressLine4.tooLong"
   val addressLine5TooLong = "global.addressLine5.tooLong"
   val postcodeInvalid = "ukAddress.postcode.invalid"
+  val postcodeBlank = "ukAddress.postcode.blank"
 
   val validData: Map[String, String] = Map(
     "addressLine1" -> "line 1",
@@ -61,7 +62,7 @@ class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
     behave like formWithMandatoryTextFields(
       MandatoryField("addressLine1", addressLine1Blank),
       MandatoryField("addressLine2", addressLine2Blank),
-      MandatoryField("postcode", postcodeInvalid))
+      MandatoryField("postcode", postcodeBlank))
 
     behave like formWithOptionalTextFields("addressLine3", "addressLine4", "addressLine5")
 
@@ -71,5 +72,7 @@ class UkAddressFormSpec extends FormBehaviours with MockitoSugar {
       MaxLengthField("addressLine3", addressLine3TooLong, addressLineMaxLength),
       MaxLengthField("addressLine4", addressLine4TooLong, addressLineMaxLength),
       MaxLengthField("addressLine5", addressLine5TooLong, addressLineMaxLength))
+
+    behave like formWithRegex(RegexField("postcode", postcodeInvalid, postcodeRegex))
   }
 }

--- a/test/forms/UniqueTaxpayerReferenceFormSpec.scala
+++ b/test/forms/UniqueTaxpayerReferenceFormSpec.scala
@@ -18,7 +18,7 @@ package forms
 
 import config.FrontendAppConfig
 import forms.behaviours.FormBehaviours
-import models.{MandatoryField, MaxLengthField}
+import models.{MandatoryField, MaxLengthField, RegexField}
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import play.api.data.Form
@@ -27,6 +27,7 @@ class UniqueTaxpayerReferenceFormSpec extends FormBehaviours with MockitoSugar {
 
   private val testRegex = """^[0-9kK]{10}$"""
   private val errorKeyInvalid = "uniqueTaxpayerReference.invalid"
+  private val errorKeyBlank = "uniqueTaxpayerReference.blank"
 
   def appConfig: FrontendAppConfig = {
     val instance = mock[FrontendAppConfig]
@@ -42,6 +43,8 @@ class UniqueTaxpayerReferenceFormSpec extends FormBehaviours with MockitoSugar {
 
     behave like questionForm("1234567890")
 
-    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyInvalid))
+    behave like formWithMandatoryTextFields(MandatoryField("value", errorKeyBlank))
+
+    behave like formWithRegex(RegexField("value", errorKeyInvalid, testRegex))
   }
 }

--- a/test/forms/behaviours/FormBehaviours.scala
+++ b/test/forms/behaviours/FormBehaviours.scala
@@ -18,7 +18,7 @@ package forms.behaviours
 
 import play.api.data.Form
 import forms.FormSpec
-import models.{MandatoryField, MaxLengthField}
+import models.{MandatoryField, MaxLengthField, RegexField}
 
 trait FormBehaviours extends FormSpec {
 
@@ -49,6 +49,17 @@ trait FormBehaviours extends FormSpec {
         val invalid = "A" * (field.maxLength + 1)
         val data = validData + (field.fieldName -> invalid)
         val expectedError = error(field.fieldName, field.errorMessageKey, field.maxLength)
+        checkForError(form, data, expectedError)
+      }
+    }
+  }
+
+  def formWithRegex(fields: RegexField*) ={
+    for (field <- fields) {
+      s"fail regex validation ${field.regexString}" in {
+        val invalid = "."
+        val data = validData + (field.fieldName -> invalid)
+        val expectedError = error(field.fieldName, field.errorMessageKey)
         checkForError(form, data, expectedError)
       }
     }

--- a/test/models/RegexField.scala
+++ b/test/models/RegexField.scala
@@ -14,20 +14,6 @@
  * limitations under the License.
  */
 
-package forms
+package models
 
-import com.google.inject.Inject
-import config.FrontendAppConfig
-import play.api.data.Form
-import play.api.data.Forms._
-
-class PartialClaimAmountForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHelper with Constraints {
-
-  private val currencyRegex = appConfig.currencyRegex
-  private val errorKeyInvalid = "partialClaimAmount.invalid"
-  private val errorKeyBlank = "partialClaimAmount.blank"
-
-  def apply(): Form[String] = Form(
-    "value" -> text.verifying(firstError(nonEmpty(errorKeyBlank), regexValidation(currencyRegex, errorKeyInvalid)))
-  )
-}
+case class RegexField(fieldName: String, errorMessageKey: String = "error.required", regexString: String)


### PR DESCRIPTION
### Description
Adding the ability to show a blank error message key rather than invalid when the user leaves an input field blank. Updated the current boolean pages.

### Issue
#81 

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [x] Not reduced code coverage unnecessarily or below acceptable threshold (run sbt scoverage to check)
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked
