### PR TITLE
Created PayeeUKAddress page and re-used UkAddress model

### DIFF
--- a/app/controllers/PayeeUKAddressController.scala
+++ b/app/controllers/PayeeUKAddressController.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import javax.inject.Inject
+
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import connectors.DataCacheConnector
+import controllers.actions._
+import config.FrontendAppConfig
+import forms.PayeeUKAddressForm
+import identifiers.PayeeUKAddressId
+import models.{Mode, UkAddress}
+import utils.{Navigator, UserAnswers}
+import views.html.payeeUKAddress
+
+import scala.concurrent.Future
+
+class PayeeUKAddressController @Inject()(appConfig: FrontendAppConfig,
+                                                  override val messagesApi: MessagesApi,
+                                                  dataCacheConnector: DataCacheConnector,
+                                                  navigator: Navigator,
+                                                  authenticate: AuthAction,
+                                                  getData: DataRetrievalAction,
+                                                  requireData: DataRequiredAction,
+                                                  formBuilder: PayeeUKAddressForm) extends FrontendController with I18nSupport {
+
+  private val form: Form[UkAddress] = formBuilder()
+
+  def onPageLoad(mode: Mode) = (authenticate andThen getData andThen requireData) {
+    implicit request =>
+      val preparedForm = request.userAnswers.payeeUKAddress match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+      Ok(payeeUKAddress(appConfig, preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (authenticate andThen getData andThen requireData).async {
+    implicit request =>
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[UkAddress]) =>
+          Future.successful(BadRequest(payeeUKAddress(appConfig, formWithErrors, mode))),
+        (value) =>
+          dataCacheConnector.save[UkAddress](request.externalId, PayeeUKAddressId.toString, value).map(cacheMap =>
+            Redirect(navigator.nextPage(PayeeUKAddressId, mode)(new UserAnswers(cacheMap))))
+      )
+  }
+}

--- a/app/forms/PayeeUKAddressForm.scala
+++ b/app/forms/PayeeUKAddressForm.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import com.google.inject.Inject
+import config.FrontendAppConfig
+import forms.mappings.Constraints
+import play.api.data.Form
+import play.api.data.Forms._
+import models.UkAddress
+
+class PayeeUKAddressForm @Inject() (appConfig: FrontendAppConfig) extends FormErrorHelper with Constraints {
+
+  private val maxLengthInt = appConfig.addressLineMaxLength
+  private val postcodeRegex = appConfig.postcodeRegex
+
+  private val addressLine1KeyBlank = "global.addressLine1.blank"
+  private val addressLine1KeyTooLong = "global.addressLine1.tooLong"
+  private val addressLine2KeyBlank = "global.addressLine2.blank"
+  private val addressLine2KeyTooLong = "global.addressLine2.tooLong"
+  private val addressLine3KeyTooLong = "global.addressLine3.tooLong"
+  private val addressLine4KeyTooLong = "global.addressLine4.tooLong"
+  private val addressLine5KeyTooLong = "global.addressLine5.tooLong"
+  private val postcodeKeyInvalid = "ukAddress.postcode.invalid"
+  private val postcodeKeyBlank = "ukAddress.postcode.blank"
+
+
+  def apply(): Form[UkAddress] = {
+    Form(
+      mapping(
+        "addressLine1" -> text.verifying(nonEmpty(addressLine1KeyBlank), maxLength(maxLengthInt, addressLine1KeyTooLong)),
+        "addressLine2" -> text.verifying(nonEmpty(addressLine2KeyBlank), maxLength(maxLengthInt, addressLine2KeyTooLong)),
+        "addressLine3" -> optional(text.verifying(maxLength(maxLengthInt, addressLine3KeyTooLong))),
+        "addressLine4" -> optional(text.verifying(maxLength(maxLengthInt, addressLine4KeyTooLong))),
+        "addressLine5" -> optional(text.verifying(maxLength(maxLengthInt, addressLine5KeyTooLong))),
+        "postcode"     -> text.verifying(firstError(nonEmpty(postcodeKeyBlank), regexValidation(postcodeRegex, postcodeKeyInvalid)))
+      )(UkAddress.apply)(UkAddress.unapply))
+  }
+}

--- a/app/identifiers/PayeeUKAddressId.scala
+++ b/app/identifiers/PayeeUKAddressId.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package identifiers
+
+case object PayeeUKAddressId extends Identifier {
+  override def toString: String = "payeeUKAddress"
+}

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -22,6 +22,10 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def payeeUKAddress: Option[AnswerRow] = userAnswers.payeeUKAddress map {
+    x => AnswerRow("payeeUKAddress.checkYourAnswersLabel", s"${x.addressLine1} ${x.addressLine2}", false, routes.PayeeUKAddressController.onPageLoad(CheckMode).url)
+  }
+  
   def whereToSendPayment: Option[AnswerRow] = userAnswers.whereToSendPayment map {
     x => AnswerRow("whereToSendPayment.checkYourAnswersLabel", s"whereToSendPayment.$x", true, routes.WhereToSendPaymentController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/Navigator.scala
+++ b/app/utils/Navigator.scala
@@ -67,7 +67,8 @@ class Navigator @Inject()() {
     WhereToSendPaymentId -> whereToSendPayment,
     PayeeFullNameId -> (_ => routes.AnyAgentRefController.onPageLoad(NormalMode)),
     AnyAgentRefId -> anyAgentRef,
-    AgentReferenceNumberId -> (_=>routes.IsPayeeAddressInTheUKController.onPageLoad(NormalMode))
+    AgentReferenceNumberId -> (_=> routes.IsPayeeAddressInTheUKController.onPageLoad(NormalMode)),
+    IsPayeeAddressInTheUKId -> isPayeeAddressInUkRoute
   )
 
   private val editRouteMap: Map[Identifier, UserAnswers => Call] = Map(
@@ -174,6 +175,12 @@ class Navigator @Inject()() {
   private def anyAgentRef (userAnswers: UserAnswers) = userAnswers.anyAgentRef match {
     case Some(true) => routes.AgentReferenceNumberController.onPageLoad(NormalMode)
     case Some(false) => routes.IsPayeeAddressInTheUKController.onPageLoad(NormalMode)
+    case None => routes.SessionExpiredController.onPageLoad()
+  }
+
+  private def isPayeeAddressInUkRoute(userAnswers: UserAnswers) = userAnswers.isPayeeAddressInTheUK match {
+    case Some(true) => routes.PayeeUKAddressController.onPageLoad(NormalMode)
+    case Some(false) => ??? //routes.InternationalAddressController.onPageLoad(NormalMode)
     case None => routes.SessionExpiredController.onPageLoad()
   }
 

--- a/app/utils/UserAnswers.scala
+++ b/app/utils/UserAnswers.scala
@@ -21,6 +21,8 @@ import identifiers._
 import models._
 
 class UserAnswers(val cacheMap: CacheMap) {
+  def payeeUKAddress: Option[UkAddress] = cacheMap.getEntry[UkAddress](PayeeUKAddressId.toString)
+
   def isPayeeAddressInTheUK: Option[Boolean] = cacheMap.getEntry[Boolean](IsPayeeAddressInTheUKId.toString)
 
   def whereToSendPayment: Option[WhereToSendPayment] = cacheMap.getEntry[WhereToSendPayment](WhereToSendPaymentId.toString)

--- a/app/views/payeeUKAddress.scala.html
+++ b/app/views/payeeUKAddress.scala.html
@@ -1,0 +1,54 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import controllers.routes._
+@import utils.FormHelpers
+@import models.{Mode, UkAddress}
+@import viewmodels.InputViewModel
+
+@(appConfig: FrontendAppConfig, form: Form[UkAddress], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = messages("payeeUKAddress.title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = PayeeUKAddressController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("payeeUKAddress.heading")
+
+        @components.input_text(InputViewModel[UkAddress]("addressLine1", form), label = messages("global.addressLine1"))
+
+        @components.input_text(InputViewModel[UkAddress]("addressLine2", form), label = messages("global.addressLine2"))
+
+        @components.input_text(InputViewModel[UkAddress]("addressLine3", form), label = messages("global.addressLine3"))
+
+        @components.input_text(InputViewModel[UkAddress]("addressLine4", form), label = messages("global.addressLine4"))
+
+        @components.input_text(InputViewModel[UkAddress]("addressLine5", form), label = messages("global.addressLine5"))
+
+        @components.input_text(InputViewModel[UkAddress]("postcode", form), label = messages("global.postcode"))
+
+        @components.submit_button()
+    }
+}
+

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -222,6 +222,11 @@ POST       /isPayeeAddressInTheUK                       controllers.IsPayeeAddre
 GET        /changeIsPayeeAddressInTheUK                       controllers.IsPayeeAddressInTheUKController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeIsPayeeAddressInTheUK                       controllers.IsPayeeAddressInTheUKController.onSubmit(mode: Mode = CheckMode)
 
+GET        /payeeUKAddress                       controllers.PayeeUKAddressController.onPageLoad(mode: Mode = NormalMode)
+POST       /payeeUKAddress                       controllers.PayeeUKAddressController.onSubmit(mode: Mode = NormalMode)
+GET        /changePayeeUKAddress                       controllers.PayeeUKAddressController.onPageLoad(mode: Mode = CheckMode)
+POST       /changePayeeUKAddress                       controllers.PayeeUKAddressController.onSubmit(mode: Mode = CheckMode)
+
 GET        /whereToSendPayment               controllers.WhereToSendPaymentController.onPageLoad(mode: Mode = NormalMode)
 POST       /whereToSendPayment               controllers.WhereToSendPaymentController.onSubmit(mode: Mode = NormalMode)
 GET        /changeWhereToSendPayment               controllers.WhereToSendPaymentController.onPageLoad(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -315,6 +315,12 @@ isPayeeAddressInTheUK.heading = Is payee address in the UK?
 isPayeeAddressInTheUK.checkYourAnswersLabel = Is payee address in the UK?
 isPayeeAddressInTheUK.blank = Select yes if the payee address is in the UK
 
+payeeUKAddress.title = payeeUKAddress
+payeeUKAddress.heading = payeeUKAddress
+payeeUKAddress.checkYourAnswersLabel = payeeUKAddress
+payeeUKAddress.postcode.invalid = Enter a valid postcode
+payeeUKAddress.postcode.blank = Enter a postcode
+
 whereToSendPayment.title = Where do you want us to send any payment?
 whereToSendPayment.heading = Where do you want us to send any payment?
 whereToSendPayment.optionYou = You

--- a/migrations/applied_migrations/PayeeUKAddress.sh
+++ b/migrations/applied_migrations/PayeeUKAddress.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+echo "Applying migration PayeeUKAddress"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /payeeUKAddress                       controllers.PayeeUKAddressController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /payeeUKAddress                       controllers.PayeeUKAddressController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changePayeeUKAddress                       controllers.PayeeUKAddressController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changePayeeUKAddress                       controllers.PayeeUKAddressController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "payeeUKAddress.title = payeeUKAddress" >> ../conf/messages.en
+echo "payeeUKAddress.heading = payeeUKAddress" >> ../conf/messages.en
+echo "payeeUKAddress.field1 = Field 1" >> ../conf/messages.en
+echo "payeeUKAddress.field2 = Field 2" >> ../conf/messages.en
+echo "payeeUKAddress.checkYourAnswersLabel = payeeUKAddress" >> ../conf/messages.en
+echo "payeeUKAddress.field1.blank = payeeUKAddress field 1 blank" >> ../conf/messages.en
+echo "payeeUKAddress.field2.blank = payeeUKAddress field 2 blank" >> ../conf/messages.en
+
+echo "Adding helper line into UserAnswers"
+awk '/class/ {\
+     print;\
+     print "  def payeeUKAddress: Option[PayeeUKAddress] = cacheMap.getEntry[PayeeUKAddress](PayeeUKAddressId.toString)";\
+     print "";\
+     next }1' ../app/utils/UserAnswers.scala > tmp && mv tmp ../app/utils/UserAnswers.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def payeeUKAddress: Option[AnswerRow] = userAnswers.payeeUKAddress map {";\
+     print "    x => AnswerRow(\"payeeUKAddress.checkYourAnswersLabel\", s\"${x.field1} ${x.field2}\", false, routes.PayeeUKAddressController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Moving test files from generated-test/ to test/"
+rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
+rm -rf ../generated-test/
+
+echo "Migration PayeeUKAddress completed"

--- a/test/controllers/PayeeUKAddressControllerSpec.scala
+++ b/test/controllers/PayeeUKAddressControllerSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import play.api.data.Form
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.cache.client.CacheMap
+import utils.FakeNavigator
+import connectors.FakeDataCacheConnector
+import controllers.actions._
+import play.api.test.Helpers._
+import forms.PayeeUKAddressForm
+import identifiers.PayeeUKAddressId
+import models.{NormalMode, UkAddress}
+import views.html.payeeUKAddress
+
+class PayeeUKAddressControllerSpec extends ControllerSpecBase {
+
+  def onwardRoute = routes.IndexController.onPageLoad()
+
+  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+    new PayeeUKAddressController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction,
+      dataRetrievalAction, new DataRequiredActionImpl, new PayeeUKAddressForm(frontendAppConfig))
+
+  val form = new PayeeUKAddressForm(frontendAppConfig)()
+
+  def viewAsString(form: Form[UkAddress] = form) = payeeUKAddress(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+
+  "PayeeUKAddress Controller" must {
+
+    "return OK and the correct view for a GET" in {
+      val result = controller().onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe viewAsString()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+      val validData = Map(PayeeUKAddressId.toString -> Json.toJson(UkAddress("line 1", "line 2", None, None, None, "NE1 7RF")))
+      val getRelevantData = new FakeDataRetrievalAction(Some(CacheMap(cacheMapId, validData)))
+
+      val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
+
+      contentAsString(result) mustBe viewAsString(form.fill(UkAddress("line 1", "line 2", None, None, None, "NE1 7RF")))
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("addressLine1", "line 1"),("addressLine2", "line 2") , ("postcode", "NE2 7RF"))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
+      val boundForm = form.bind(Map("value" -> "invalid value"))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe BAD_REQUEST
+      contentAsString(result) mustBe viewAsString(boundForm)
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+      val result = controller(dontGetAnyData).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("addressLine1", "line 1"), ("addressLine2", "line 2"), ("postcode", "NE1 6RF"))
+      val result = controller(dontGetAnyData).onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(routes.SessionExpiredController.onPageLoad().url)
+    }
+  }
+}

--- a/test/forms/PayeeUKAddressFormSpec.scala
+++ b/test/forms/PayeeUKAddressFormSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import config.FrontendAppConfig
+import forms.behaviours.FormBehaviours
+import models.{MandatoryField, MaxLengthField, RegexField, UkAddress}
+import org.scalatest.mockito.MockitoSugar
+import play.api.data.Form
+import org.mockito.Mockito._
+
+class PayeeUKAddressFormSpec extends FormBehaviours with MockitoSugar {
+
+  val addressLineMaxLength = 35
+  val postcodeRegex = """([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})"""
+
+  def appConfig: FrontendAppConfig = {
+    val instance = mock[FrontendAppConfig]
+    when(instance.addressLineMaxLength) thenReturn addressLineMaxLength
+    when(instance.postcodeRegex) thenReturn postcodeRegex
+    instance
+  }
+
+  val addressLine1Blank = "global.addressLine1.blank"
+  val addressLine1TooLong = "global.addressLine1.tooLong"
+  val addressLine2Blank = "global.addressLine2.blank"
+  val addressLine2TooLong = "global.addressLine2.tooLong"
+  val addressLine3TooLong = "global.addressLine3.tooLong"
+  val addressLine4TooLong = "global.addressLine4.tooLong"
+  val addressLine5TooLong = "global.addressLine5.tooLong"
+  val postcodeInvalid = "ukAddress.postcode.invalid"
+  val postcodeBlank = "ukAddress.postcode.blank"
+
+  val validData: Map[String, String] = Map(
+    "addressLine1" -> "line 1",
+    "addressLine2" -> "line 2",
+    "addressLine3" -> "line 3",
+    "addressLine4" -> "line 4",
+    "addressLine5" -> "line 5",
+    "postcode" -> "NE1 7RF"
+  )
+
+  override val form: Form[UkAddress] = new PayeeUKAddressForm(appConfig)()
+
+  "PayeeUKAddress form" must {
+    behave like questionForm(UkAddress("line 1", "line 2", Some("line 3"), Some("line 4"), Some("line 5"), "NE1 7RF"))
+
+    behave like formWithMandatoryTextFields(
+      MandatoryField("addressLine1", addressLine1Blank),
+      MandatoryField("addressLine2", addressLine2Blank),
+      MandatoryField("postcode", postcodeBlank))
+
+    behave like formWithOptionalTextFields("addressLine3", "addressLine4", "addressLine5")
+
+    behave like formWithMaxLengthTextFields(
+      MaxLengthField("addressLine1", addressLine1TooLong, addressLineMaxLength),
+      MaxLengthField("addressLine2", addressLine2TooLong, addressLineMaxLength),
+      MaxLengthField("addressLine3", addressLine3TooLong, addressLineMaxLength),
+      MaxLengthField("addressLine4", addressLine4TooLong, addressLineMaxLength),
+      MaxLengthField("addressLine5", addressLine5TooLong, addressLineMaxLength))
+
+    behave like formWithRegex(RegexField("postcode", postcodeInvalid, postcodeRegex))
+  }
+}

--- a/test/utils/NavigatorSpec.scala
+++ b/test/utils/NavigatorSpec.scala
@@ -335,6 +335,11 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
         navigator.nextPage(AnyAgentRefId, NormalMode)(answers) mustBe routes.IsPayeeAddressInTheUKController.onPageLoad(NormalMode)
       }
 
+      "go to payeeUKAddress from IsPayeeAddressInTheUK when Yes is selected" in {
+        val answers = mock[UserAnswers]
+        when(answers.isPayeeAddressInTheUK) thenReturn Some(true)
+        navigator.nextPage(IsPayeeAddressInTheUKId, NormalMode)(answers) mustBe routes.PayeeUKAddressController.onPageLoad(NormalMode)
+      }
     }
 
     "in Check mode" must {

--- a/test/views/PayeeUKAddressViewSpec.scala
+++ b/test/views/PayeeUKAddressViewSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import config.FrontendAppConfig
+import play.api.data.Form
+import controllers.routes
+import forms.PayeeUKAddressForm
+import models.{NormalMode, UkAddress}
+import org.scalatest.mockito.MockitoSugar
+import views.behaviours.QuestionViewBehaviours
+import views.html.payeeUKAddress
+
+class PayeeUKAddressViewSpec extends QuestionViewBehaviours[UkAddress] with MockitoSugar {
+
+  val messageKeyPrefix = "payeeUKAddress"
+
+  val appConfig: FrontendAppConfig = mock[FrontendAppConfig]
+
+  override val form: Form[UkAddress] = new PayeeUKAddressForm(appConfig)()
+
+  def createView = () => payeeUKAddress(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  def createViewUsingForm = (form: Form[UkAddress]) => payeeUKAddress(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  "PayeeUKAddress view" must {
+
+    behave like normalPage(createView, messageKeyPrefix)
+
+    behave like pageWithBackLink(createView)
+
+    behave like pageWithTextFields(createViewUsingForm, messageKeyPrefix, routes.PayeeUKAddressController.onSubmit(NormalMode)
+      .url, "addressLine1", "addressLine2", "addressLine3", "addressLine4", "addressLine5", "postcode")
+  }
+}


### PR DESCRIPTION
### Description
Created a new PayeeUKAddress page and re-used the UkAddress model.

### Issue
#170 

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [x] Use g8Scaffold to create page, run migrate script and then run sbt test
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked

