### PR TITLE
Add hint text other benefits

### DIFF
--- a/app/views/components/input_textarea.scala.html
+++ b/app/views/components/input_textarea.scala.html
@@ -22,12 +22,13 @@ label: String,
 secondaryLabel: Option[String] = None,
 inputClass: Option[String] = None,
 hint: Option[String] = None,
-charLimit: Option[Int] = None
+charLimit: Option[Int] = None,
+labelClass: Option[String] = None
 )(implicit messages: Messages)
 
 <div class="form-field @if(viewModel.errorKey != ""){form-field--error}">
     <label class="form-label" for="@{viewModel.id}">
-        <span class="bold">@label</span>
+        <span class="bold @if(labelClass.nonEmpty){@labelClass}">@label</span>
         @if(hint != ""){
         <span class="form-hint">@hint</span>
         }

--- a/app/views/otherBenefitsDetailsAndAmount.scala.html
+++ b/app/views/otherBenefitsDetailsAndAmount.scala.html
@@ -35,7 +35,11 @@
 
         @components.heading("otherBenefitsDetailsAndAmount.heading")
 
-        @components.input_textarea(InputViewModel("value", form), label = messages("otherBenefitsDetailsAndAmount.heading"))
+        @components.input_textarea(InputViewModel("value", form),
+            label = messages("otherBenefitsDetailsAndAmount.heading"),
+            labelClass = Some("visually-hidden"),
+            hint = Some(messages("otherBenefitsDetailsAndAmount.hint"))
+            )
 
         @components.submit_button()
     }

--- a/app/views/otherIncomeDetailsAndAmount.scala.html
+++ b/app/views/otherIncomeDetailsAndAmount.scala.html
@@ -35,7 +35,10 @@
 
         @components.heading("otherIncomeDetailsAndAmount.heading")
 
-        @components.input_textarea(InputViewModel("value", form), label = messages("otherIncomeDetailsAndAmount.heading"))
+        @components.input_textarea(InputViewModel("value", form),
+         label = messages("otherIncomeDetailsAndAmount.heading"),
+         labelClass = Some("visually-hidden"),
+         hint = Some(messages("otherIncomeDetailsAndAmount.hint")))
 
         @components.submit_button()
     }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -302,6 +302,12 @@ otherIncomeDetailsAndAmount.checkYourAnswersLabel = Other taxable income you got
 otherIncomeDetailsAndAmount.blank = Enter the other taxable income you got in the tax year your claim is for
 otherIncomeDetailsAndAmount.hint = Enter the type of income and the amounts you got.
 
+otherIncomeDetailsAndAmount.title = What other taxable income did you get in the tax year your claim is for?
+otherIncomeDetailsAndAmount.heading = What other taxable income did you get in the tax year your claim is for?
+otherIncomeDetailsAndAmount.checkYourAnswersLabel = Other taxable income you got in the tax year your claim is for
+otherIncomeDetailsAndAmount.blank = Enter the other taxable income you got in the tax year your claim is for
+otherIncomeDetailsAndAmount.hint = Enter the type of income and the amounts you got.
+
 payeeFullName.title = What is the full name of the person you want us to send any payment to?
 payeeFullName.heading = What is the full name of the person you want us to send any payment to?
 payeeFullName.checkYourAnswersLabel = Full name of the person you want us to send any payment to

--- a/test/views/OtherBenefitsDetailsAndAmountViewSpec.scala
+++ b/test/views/OtherBenefitsDetailsAndAmountViewSpec.scala
@@ -42,6 +42,7 @@ class OtherBenefitsDetailsAndAmountViewSpec extends StringViewBehaviours with Mo
 
     behave like pageWithBackLink(createView)
 
-    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.OtherBenefitsDetailsAndAmountController.onSubmit(NormalMode).url)
+    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.OtherBenefitsDetailsAndAmountController.onSubmit(NormalMode).url,
+     Some(s"$messageKeyPrefix.hint"))
   }
 }

--- a/test/views/OtherIncomeDetailsAndAmountViewSpec.scala
+++ b/test/views/OtherIncomeDetailsAndAmountViewSpec.scala
@@ -42,6 +42,7 @@ class OtherIncomeDetailsAndAmountViewSpec extends StringViewBehaviours with Mock
 
     behave like pageWithBackLink(createView)
 
-    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.OtherIncomeDetailsAndAmountController.onSubmit(NormalMode).url)
+    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.OtherIncomeDetailsAndAmountController.onSubmit(NormalMode).url,
+      Some(s"$messageKeyPrefix.hint"))
   }
 }

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -48,7 +48,6 @@ trait ViewBehaviours extends ViewSpecBase {
           val doc = asDocument(view())
           for (key <- expectedGuidanceKeys) assertContainsText(doc, messages(s"$messageKeyPrefix.$key"))
         }
-
       }
     }
   }
@@ -62,4 +61,15 @@ trait ViewBehaviours extends ViewSpecBase {
       }
     }
   }
+
+//  def pageWithHintText(view: () => HtmlFormat.Appendable,
+//                       messageKeyPrefix: String) = {
+//    "behave like a page with hint text" must {
+//      "display the correct hint text" in {
+//        val doc = asDocument(view())
+//        assertContainsText(doc, messages(s"$messageKeyPrefix.hint"))
+//      }
+//
+//    }
+//  }
 }


### PR DESCRIPTION
### Description
Added hintext to OtherBenefitsDetailsAndAmount and OtherIncomeDetailsAndAmount
Fixed input_textarea component so that it hides form label.

### Issue
#153

### Have you done the following
<!--- Please indicate that you have completed the following -->
- [x] Use g8Scaffold to create page, run migrate script and then run sbt test
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked

  