### PR TITLE
Fixed tax year summary visibility

### DIFF
--- a/app/utils/CheckYourAnswersSection.scala
+++ b/app/utils/CheckYourAnswersSection.scala
@@ -43,6 +43,7 @@ class CheckYourAnswersSections (cyaHelper: CheckYourAnswersHelper, userAnswers: 
   ).flatten)
 
   def incomeDetails = AnswerSection(Some("checkYourAnswers.incomeDetailsSection"), Seq(
+    cyaHelper.selectTaxYear,
     cyaHelper.anyBenefits,
     cyaHelper.otherIncome
   ).flatten)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -302,12 +302,6 @@ otherIncomeDetailsAndAmount.checkYourAnswersLabel = Other taxable income you got
 otherIncomeDetailsAndAmount.blank = Enter the other taxable income you got in the tax year your claim is for
 otherIncomeDetailsAndAmount.hint = Enter the type of income and the amounts you got.
 
-otherIncomeDetailsAndAmount.title = What other taxable income did you get in the tax year your claim is for?
-otherIncomeDetailsAndAmount.heading = What other taxable income did you get in the tax year your claim is for?
-otherIncomeDetailsAndAmount.checkYourAnswersLabel = Other taxable income you got in the tax year your claim is for
-otherIncomeDetailsAndAmount.blank = Enter the other taxable income you got in the tax year your claim is for
-otherIncomeDetailsAndAmount.hint = Enter the type of income and the amounts you got.
-
 payeeFullName.title = What is the full name of the person you want us to send any payment to?
 payeeFullName.heading = What is the full name of the person you want us to send any payment to?
 payeeFullName.checkYourAnswersLabel = Full name of the person you want us to send any payment to

--- a/test/utils/CheckYourAnswersSectionsSpec.scala
+++ b/test/utils/CheckYourAnswersSectionsSpec.scala
@@ -17,6 +17,7 @@
 package utils
 
 import base.SpecBase
+import models.SelectTaxYear.Option1
 import models.WhereToSendPayment.OptionSomeoneElse
 import models._
 import org.scalatest.mockito.MockitoSugar
@@ -190,6 +191,21 @@ class CheckYourAnswersSectionsSpec extends SpecBase with MockitoSugar with Befor
       rows(2).label mustBe "anyAgentRef.checkYourAnswersLabel"
       rows(3).label mustBe "isPayeeAddressInTheUK.checkYourAnswersLabel"
       rows(4).label mustBe "payeeInternationalAddress.checkYourAnswersLabel"
+    }
+
+    "have the correct rows in the right order in the Income Details section" in {
+      when(answers.selectTaxYear) thenReturn Some(Option1)
+      when(answers.anyBenefits) thenReturn Some(false)
+      when(answers.otherIncome) thenReturn Some(false)
+
+      val helper = new CheckYourAnswersHelper(answers)
+      val sections = new CheckYourAnswersSections(helper, MockUserAnswers.minimalValidUserAnswers)
+      val rows = sections.incomeDetails.rows
+
+      rows.size mustBe 3
+      rows.head.label mustBe "selectTaxYear.checkYourAnswersLabel"
+      rows(1).label mustBe "anyBenefits.checkYourAnswersLabel"
+      rows(2).label mustBe "otherIncome.checkYourAnswersLabel"
     }
   }
 }


### PR DESCRIPTION
### Description
Fixed select a tax year visibility on the summary page, also removed duplicate text.
### Issue
#CTR-11
### Have you done the following
- [x] Run sbt test on the change to ensure it doesn't have unexpected effects
- [x] Run the service locally to ensure the change has actually worked