### PR TITLE
DL-1810 Ensure unit tests use fixed dates

### DIFF
--- a/app/models/SelectTaxYear.scala
+++ b/app/models/SelectTaxYear.scala
@@ -20,7 +20,7 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.time.TaxYear
 import utils._
 
-sealed trait SelectTaxYear {
+trait SelectTaxYear {
   def year: Int
   def asString(implicit messages: Messages): String
 }
@@ -64,6 +64,15 @@ object SelectTaxYear extends Enumerable[SelectTaxYear] {
         TaxYear.current.back(4).startYear.toString.format(dateFormat),
         TaxYear.current.back(4).finishYear.toString.format(dateFormat)
       )
+  }
+
+  case class CustomTaxYear(year: Int) extends SelectTaxYear {
+    override def asString(implicit messages: Messages): String = s"6 April $year to 5 April ${year + 1}"
+  }
+
+  private val regex = "CustomTaxYear\\(([0-9]+)\\)".r
+  def harnessReads: PartialFunction[String, SelectTaxYear] = PartialFunction[String, SelectTaxYear] {
+    case regex(y) => CustomTaxYear(y.toInt)
   }
 
   def options: Seq[RadioOption] = Seq(

--- a/app/models/WhereToSendPayment.scala
+++ b/app/models/WhereToSendPayment.scala
@@ -29,4 +29,6 @@ object WhereToSendPayment extends Enumerable[WhereToSendPayment] {
   lazy val values: Set[WhereToSendPayment] = Set(
     Myself, Nominee
   )
+
+  override def harnessReads: PartialFunction[String, WhereToSendPayment] = PartialFunction.empty
 }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -17,7 +17,7 @@
 package utils
 
 import controllers.routes
-import models.SelectTaxYear.{CYMinus1, CYMinus2, CYMinus3, CYMinus4}
+import models.SelectTaxYear.{CYMinus1, CYMinus2, CYMinus3, CYMinus4, CustomTaxYear}
 import models._
 import play.api.i18n.Messages
 import uk.gov.hmrc.auth.core.retrieve.ItmpAddress
@@ -41,6 +41,8 @@ class CheckYourAnswersHelper(userAnswers: UserAnswers)(implicit messages: Messag
             CYMinus3.asString
           case CYMinus4 =>
             CYMinus4.asString
+          case year @ CustomTaxYear(y) =>
+            year.asString
         },
 				url = Some(routes.SelectTaxYearController.onPageLoad(CheckMode).url),
 				changeLabel = "selectTaxYear.changeLabel")

--- a/app/utils/Enumerable.scala
+++ b/app/utils/Enumerable.scala
@@ -22,6 +22,8 @@ trait Enumerable[A] {
 
   def values: Set[A]
 
+  def harnessReads: PartialFunction[String, A]
+
   def withName(str: String): Option[A] =
     mappings.get(str)
 
@@ -35,6 +37,8 @@ trait Enumerable[A] {
     Reads {
       case JsString(str) if mappings.contains(str) =>
         JsSuccess(mappings(str))
+      case JsString(str) if harnessReads.isDefinedAt(str) =>
+        JsSuccess(harnessReads(str))
       case _ =>
         JsError("error.invalid")
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,8 @@ resolvers += "HMRC Artifactory Releases" at "https://artefacts.tax.service.gov.u
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
+libraryDependencies += "io.monix" %% "monix" % "2.3.0" pomOnly()
+
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")

--- a/test/controllers/AddressLookupRoutingControllerSpec.scala
+++ b/test/controllers/AddressLookupRoutingControllerSpec.scala
@@ -33,7 +33,7 @@ class AddressLookupRoutingControllerSpec extends ControllerSpecBase with Mockito
   def onwardRoute = routes.IndexController.onPageLoad()
 
   private val mockAddressLookup: AddressLookupConnector = mock[AddressLookupConnector]
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new AddressLookupRoutingController(frontendAppConfig, new FakeNavigator(desiredRoute = onwardRoute), mockAddressLookup, FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/AnyAgentRefControllerSpec.scala
+++ b/test/controllers/AnyAgentRefControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.AnyAgentReferenceForm
 import identifiers.{AgentRefId, AnyAgentRefId}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyAgentRef, NormalMode}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -41,8 +41,8 @@ class AnyAgentRefControllerSpec extends ControllerSpecBase {
   val form: Form[AnyAgentRef] = formProvider(messages(requiredKey, nomineeName), messages(requiredAgentRefKey, nomineeName))
   val validYesData = Map(AnyAgentRefId.toString -> Json.obj(AnyAgentRefId.toString -> JsBoolean(true), AgentRefId.toString -> JsString("AB1234")))
   val validNoData = Map(AnyAgentRefId.toString -> Json.obj(AnyAgentRefId.toString -> JsBoolean(false)))
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new AnyAgentRefController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/AnyBenefitsControllerSpec.scala
+++ b/test/controllers/AnyBenefitsControllerSpec.scala
@@ -21,7 +21,7 @@ import connectors.{FakeDataCacheConnector, TaiConnector}
 import controllers.actions._
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -37,8 +37,8 @@ class AnyBenefitsControllerSpec extends ControllerSpecBase with MockitoSugar {
   val formProvider = new BooleanForm()
   val form = formProvider()
   val mockTai: TaiConnector = mock[TaiConnector]
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new AnyBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, mockTai, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/AnyCompanyBenefitsControllerSpec.scala
+++ b/test/controllers/AnyCompanyBenefitsControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -34,8 +34,8 @@ class AnyCompanyBenefitsControllerSpec extends ControllerSpecBase {
 
   val formProvider = new BooleanForm()
   val form = formProvider()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new AnyCompanyBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
@@ -46,7 +46,7 @@ class AnyCompanyBenefitsControllerSpec extends ControllerSpecBase {
   "AnyCompanyBenefits Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller(someData).onPageLoad(NormalMode)(fakeRequest)
+      val result = controller(someData()).onPageLoad(NormalMode)(fakeRequest)
 
       status(result) mustBe OK
       contentAsString(result) mustBe viewAsString()

--- a/test/controllers/AnyOtherBenefitsControllerSpec.scala
+++ b/test/controllers/AnyOtherBenefitsControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
 import models.{CheckMode, Mode, NormalMode, SelectTaxYear}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.mvc.Call
@@ -36,8 +36,8 @@ class AnyOtherBenefitsControllerSpec extends ControllerSpecBase {
 
   val formProvider = new BooleanForm()
   val form = formProvider()
-  private val taxYear: SelectTaxYear = CYMinus2
-  private val mockUserAnswers: UserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear: SelectTaxYear = CustomTaxYear(2017)
+  private val mockUserAnswers: UserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   private val cya: CheckYourAnswersHelper = new CheckYourAnswersHelper(mockUserAnswers)(messages)
   private val otherBenefitsSection: AnswerSection = new CheckYourAnswersSections(cya, mockUserAnswers).otherBenefitsSection

--- a/test/controllers/AnyOtherCompanyBenefitsControllerSpec.scala
+++ b/test/controllers/AnyOtherCompanyBenefitsControllerSpec.scala
@@ -23,7 +23,7 @@ import controllers.actions._
 import play.api.test.Helpers._
 import forms.BooleanForm
 import models.{CheckMode, Mode, NormalMode, OtherCompanyBenefit}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.mvc.Call
 import viewmodels.AnswerSection
@@ -36,8 +36,8 @@ class AnyOtherCompanyBenefitsControllerSpec extends ControllerSpecBase {
 
   val formProvider = new BooleanForm()
   val form = formProvider()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
   private val cya: CheckYourAnswersHelper = new CheckYourAnswersHelper(mockUserAnswers)(messages)
   private val otherCompanyBenefits: AnswerSection = new CheckYourAnswersSections(cya, mockUserAnswers).otherBenefitsAddToListNormalMode
 

--- a/test/controllers/AnyOtherTaxableIncomeControllerSpec.scala
+++ b/test/controllers/AnyOtherTaxableIncomeControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models._
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -35,8 +35,8 @@ class AnyOtherTaxableIncomeControllerSpec extends ControllerSpecBase {
 
   private val formProvider = new BooleanForm()
   private val form = formProvider()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   val complete: Seq[(OtherTaxableIncome, Int)] = Seq((OtherTaxableIncome("qwerty", "123", Some(AnyTaxPaid.Yes("1234"))),0))
   val incomplete: Seq[(OtherTaxableIncome, Int)] = Seq((OtherTaxableIncome("qwerty", "123", None),1))

--- a/test/controllers/AnyTaxableBankInterestControllerSpec.scala
+++ b/test/controllers/AnyTaxableBankInterestControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.AnyTaxPaidForm
 import identifiers.{AnyTaxPaidId, TaxPaidAmountId}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -41,8 +41,8 @@ class AnyTaxableBankInterestControllerSpec extends ControllerSpecBase {
   val testAnswer = "9,999.00"
   val validYesData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(true), TaxPaidAmountId.toString -> JsString(testAnswer)))
   val validNoData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(false)))
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
-  private val taxYear = CYMinus2
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm
   private val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/controllers/AnyTaxableForeignIncomeControllerSpec.scala
+++ b/test/controllers/AnyTaxableForeignIncomeControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.AnyTaxPaidForm
 import identifiers.{AnyTaxPaidId, TaxPaidAmountId}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -41,8 +41,8 @@ class AnyTaxableForeignIncomeControllerSpec extends ControllerSpecBase {
   val testAnswer = "9,999.00"
   val validYesData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(true), TaxPaidAmountId.toString -> JsString(testAnswer)))
   val validNoData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(false)))
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
-  private val taxYear = CYMinus2
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm
   private val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/controllers/AnyTaxableIncomeControllerSpec.scala
+++ b/test/controllers/AnyTaxableIncomeControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -34,8 +34,8 @@ class AnyTaxableIncomeControllerSpec extends ControllerSpecBase {
 
   val formProvider = new BooleanForm()
   val form = formProvider()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new AnyTaxableIncomeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/AnyTaxableInvestmentsControllerSpec.scala
+++ b/test/controllers/AnyTaxableInvestmentsControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.AnyTaxPaidForm
 import identifiers.{AnyTaxPaidId, TaxPaidAmountId}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -41,8 +41,8 @@ class AnyTaxableInvestmentsControllerSpec extends ControllerSpecBase {
   val testAnswer = "9,999.00"
   val validYesData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(true), TaxPaidAmountId.toString -> JsString(testAnswer)))
   val validNoData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(false)))
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
-  private val taxYear = CYMinus2
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm
   private val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/controllers/AnyTaxableOtherIncomeControllerSpec.scala
+++ b/test/controllers/AnyTaxableOtherIncomeControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.{AnyTaxPaidForm, OtherTaxableIncomeForm}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode, OtherTaxableIncome}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -38,8 +38,8 @@ class AnyTaxableOtherIncomeControllerSpec extends ControllerSpecBase {
   private val invalidKey = "anyTaxableOtherIncome.invalid"
 
   private val testAnswer = "9,999.00"
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
-  private val taxYear = CYMinus2
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
+  private val taxYear = CustomTaxYear(2017)
   private val incomeName = "test income"
 
   private val formProvider = new OtherTaxableIncomeForm(frontendAppConfig)

--- a/test/controllers/AnyTaxableRentalIncomeControllerSpec.scala
+++ b/test/controllers/AnyTaxableRentalIncomeControllerSpec.scala
@@ -24,7 +24,7 @@ import controllers.actions._
 import play.api.test.Helpers._
 import forms.AnyTaxPaidForm
 import identifiers.{AnyTaxPaidId, TaxPaidAmountId}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import org.mockito.Mockito.when
 import views.html.anyTaxableRentalIncome
@@ -41,8 +41,8 @@ class AnyTaxableRentalIncomeControllerSpec extends ControllerSpecBase {
   val testAnswer = "9,999.00"
   val validYesData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(true), TaxPaidAmountId.toString -> JsString(testAnswer)))
   val validNoData = Map(AnyTaxPaidId.toString -> Json.obj(AnyTaxPaidId.toString -> JsBoolean(false)))
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
-  private val taxYear = CYMinus2
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm
   private val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -58,7 +58,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpecBase with ScalaFuture
   "Check Your Answers Controller" must {
 
     "return 200 and the correct view for a GET" in {
-      val result = controller(someData).onPageLoad()(fakeRequest)
+      val result = controller(someData()).onPageLoad()(fakeRequest)
       status(result) mustBe OK
     }
 
@@ -71,7 +71,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpecBase with ScalaFuture
 
     "return RuntimeException" in {
       when(dataCacheConnector.save(any(), any(), any())(any())) thenReturn Future.failed(new RuntimeException)
-      val result = controller(someData).onSubmit()(fakeRequest)
+      val result = controller(someData()).onSubmit()(fakeRequest)
 
       whenReady(result.failed) {
         result =>
@@ -91,7 +91,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpecBase with ScalaFuture
 
     "throw an exception when a submission fails" in {
       when(mockSubmissionService.ctrSubmission(any())(any())) thenReturn Future.successful(SubmissionFailed)
-      val result = controller(someData).onSubmit()(fakeRequest)
+      val result = controller(someData()).onSubmit()(fakeRequest)
 
       whenReady(result.failed) {
         result =>

--- a/test/controllers/ConfirmationControllerSpec.scala
+++ b/test/controllers/ConfirmationControllerSpec.scala
@@ -34,7 +34,7 @@ class ConfirmationControllerSpec extends ControllerSpecBase with ScalaFutures{
 	val mockDataCacheConnector = mock[DataCacheConnector]
   def onwardRoute: Call = routes.IndexController.onPageLoad()
 
-  def controller(dataRetrievalAction: DataRetrievalAction = someData) =
+  def controller(dataRetrievalAction: DataRetrievalAction = someData()) =
     new ConfirmationController(frontendAppConfig, messagesApi, FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), messagesControllerComponents, mockDataCacheConnector, formPartialRetriever, scalate)
 
@@ -46,7 +46,7 @@ class ConfirmationControllerSpec extends ControllerSpecBase with ScalaFutures{
   "Confirmation Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val mockUserAnswers: UserAnswers = MockUserAnswers.minimalValidUserAnswers
+      val mockUserAnswers: UserAnswers = MockUserAnswers.minimalValidUserAnswers()
 			when(mockUserAnswers.cacheMap) thenReturn CacheMap(cacheMapId, Map())
 			val result = controller(fakeDataRetrievalAction(mockUserAnswers)).onPageLoad(NormalMode)(fakeRequest)
 			status(result) mustBe OK

--- a/test/controllers/ControllerSpecBase.scala
+++ b/test/controllers/ControllerSpecBase.scala
@@ -41,13 +41,13 @@ trait ControllerSpecBase extends SpecBase {
 
   def dontGetAnyData = new FakeDataRetrievalAction(None)
 
-  def someData = new FakeDataRetrievalAction(
-    Some(CacheMap(cacheMapId, Map(SelectTaxYearId.toString -> Json.toJson(SelectTaxYear.CYMinus2))))
+  def someData(year: Int = 2017) = new FakeDataRetrievalAction(
+    Some(CacheMap(cacheMapId, Map(SelectTaxYearId.toString -> Json.toJson(SelectTaxYear.CustomTaxYear(year)))))
   )
 
   implicit lazy val cc: MessagesControllerComponents = messagesControllerComponents
 
-  def fakeDataRetrievalAction(mockUserAnswers: UserAnswers = MockUserAnswers.minimalValidUserAnswers): DataRetrievalAction =
+  def fakeDataRetrievalAction(mockUserAnswers: UserAnswers = MockUserAnswers.minimalValidUserAnswers()): DataRetrievalAction =
     new DataRetrievalAction {
       override protected def transform[A](request: AuthenticatedRequest[A]): Future[OptionalDataRequest[A]] = {
         Future.successful(OptionalDataRequest(

--- a/test/controllers/DeleteOtherControllerSpec.scala
+++ b/test/controllers/DeleteOtherControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models._
 import org.mockito.Mockito._
 import play.api.data.Form
@@ -36,7 +36,7 @@ class DeleteOtherControllerSpec extends ControllerSpecBase {
   val formProvider = new BooleanForm()
   val form = formProvider()
   private val mockUserAnswers = MockUserAnswers
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val itemName = "qwerty"
 
@@ -59,7 +59,7 @@ class DeleteOtherControllerSpec extends ControllerSpecBase {
   "DeleteOther Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller(fakeDataRetrievalAction(mockUserAnswers.minimalValidUserAnswers))
+      val result = controller(fakeDataRetrievalAction(mockUserAnswers.minimalValidUserAnswers()))
         .onPageLoad(NormalMode, index, itemName, benefitCollectionId)(fakeRequest)
 
       status(result) mustBe OK
@@ -69,7 +69,7 @@ class DeleteOtherControllerSpec extends ControllerSpecBase {
     "redirect to AnyOtherBenefit when value is true and valid benefit submitted" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "true"))
 
-      val result = controller(fakeDataRetrievalAction(mockUserAnswers.benefitsUserAnswers))
+      val result = controller(fakeDataRetrievalAction(mockUserAnswers.benefitsUserAnswers()))
         .onSubmit(CheckMode, index, itemName, benefitCollectionId)(postRequest)
 
       status(result) mustBe SEE_OTHER
@@ -78,7 +78,7 @@ class DeleteOtherControllerSpec extends ControllerSpecBase {
 
     "redirect to RemoveOtherSelectedOption when value is true and no other benefits are available" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "true"))
-      val answers = mockUserAnswers.benefitsUserAnswers
+      val answers = mockUserAnswers.benefitsUserAnswers()
 
       when(answers.otherBenefit) thenReturn Some(Seq.empty)
 
@@ -249,7 +249,7 @@ class DeleteOtherControllerSpec extends ControllerSpecBase {
     }
 
     "redirect to Session Expired for a GET if no taxYear is available" in {
-      val minimalValidUserAnswers = mockUserAnswers.minimalValidUserAnswers
+      val minimalValidUserAnswers = mockUserAnswers.minimalValidUserAnswers()
 
       when(minimalValidUserAnswers.selectTaxYear) thenReturn None
 

--- a/test/controllers/DetailsOfEmploymentOrPensionControllerSpec.scala
+++ b/test/controllers/DetailsOfEmploymentOrPensionControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.DetailsOfEmploymentOrPensionForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -38,9 +38,9 @@ class DetailsOfEmploymentOrPensionControllerSpec extends ControllerSpecBase {
 
   private val form = new DetailsOfEmploymentOrPensionForm(frontendAppConfig)()
   private val testAnswer = "This is some sample text"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
   private val characterLimit = 500
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
 
   def viewAsString(form: Form[_] = form) =
@@ -49,7 +49,7 @@ class DetailsOfEmploymentOrPensionControllerSpec extends ControllerSpecBase {
   "DetailsOfEmploymentOrPension Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller(someData).onPageLoad(NormalMode)(fakeRequest)
+      val result = controller(someData()).onPageLoad(NormalMode)(fakeRequest)
 
       status(result) mustBe OK
       contentAsString(result) mustBe viewAsString()

--- a/test/controllers/EmploymentDetailsControllerSpec.scala
+++ b/test/controllers/EmploymentDetailsControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.{FakeDataCacheConnector, TaiConnector}
 import controllers.actions._
 import forms.BooleanForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.{CYMinus2, CustomTaxYear}
 import models.{Employment, NormalMode}
 import org.mockito.Matchers
 import org.mockito.Mockito.when
@@ -28,6 +28,7 @@ import play.api.data.Form
 import play.api.test.Helpers._
 import utils.{FakeNavigator, MockUserAnswers}
 import views.html.employmentDetails
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -39,8 +40,8 @@ class EmploymentDetailsControllerSpec extends ControllerSpecBase with MockitoSug
   val formProvider = new BooleanForm()
   val form = formProvider()
   val mockTaiConnector = mock[TaiConnector]
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =

--- a/test/controllers/EnterPayeReferenceControllerSpec.scala
+++ b/test/controllers/EnterPayeReferenceControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.EnterPayeReferenceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -38,15 +38,15 @@ class EnterPayeReferenceControllerSpec extends ControllerSpecBase {
 
   val testAnswer = "123/AB1234"
   val form = new EnterPayeReferenceForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def viewAsString(form: Form[_] = form) = enterPayeReference(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, formPartialRetriever, scalate).toString
 
   "EnterPayeReference Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller(someData).onPageLoad(NormalMode)(fakeRequest)
+      val result = controller(someData()).onPageLoad(NormalMode)(fakeRequest)
 
       status(result) mustBe OK
       contentAsString(result) mustBe viewAsString()

--- a/test/controllers/HowMuchBankInterestControllerSpec.scala
+++ b/test/controllers/HowMuchBankInterestControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchBankInterestForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -34,8 +34,8 @@ class HowMuchBankInterestControllerSpec extends ControllerSpecBase {
 
   private val testAnswer = "9,999.99"
   private val form = new HowMuchBankInterestForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new HowMuchBankInterestController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/HowMuchBereavementAllowanceControllerSpec.scala
+++ b/test/controllers/HowMuchBereavementAllowanceControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchBereavementAllowanceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -37,10 +37,10 @@ class HowMuchBereavementAllowanceControllerSpec extends ControllerSpecBase {
       frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), messagesControllerComponents, new HowMuchBereavementAllowanceForm(frontendAppConfig), formPartialRetriever, scalate)
 
-  val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   val testAnswer = "9,999.99"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
   val form = new HowMuchBereavementAllowanceForm(frontendAppConfig)()
 
   def viewAsString(form: Form[_] = form) = howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, formPartialRetriever, scalate).toString
@@ -48,7 +48,7 @@ class HowMuchBereavementAllowanceControllerSpec extends ControllerSpecBase {
   "HowMuchBereavementAllowance Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller(someData).onPageLoad(NormalMode)(fakeRequest)
+      val result = controller(someData()).onPageLoad(NormalMode)(fakeRequest)
 
       status(result) mustBe OK
       contentAsString(result) mustBe viewAsString()

--- a/test/controllers/HowMuchCarBenefitsControllerSpec.scala
+++ b/test/controllers/HowMuchCarBenefitsControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchCarBenefitsForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -35,8 +35,8 @@ class HowMuchCarBenefitsControllerSpec extends ControllerSpecBase with MockitoSu
 
   val testAnswer = "9,999.99"
   val form = new HowMuchCarBenefitsForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new HowMuchCarBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/HowMuchCarersAllowanceControllerSpec.scala
+++ b/test/controllers/HowMuchCarersAllowanceControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.Helpers._
 import forms.HowMuchCarersAllowanceForm
 import identifiers.HowMuchCarersAllowanceId
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import views.html.howMuchCarersAllowance
 import org.mockito.Mockito.when
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -40,9 +40,9 @@ class HowMuchCarersAllowanceControllerSpec extends ControllerSpecBase {
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), messagesControllerComponents, new HowMuchCarersAllowanceForm(frontendAppConfig), formPartialRetriever, scalate)
 
   val testAnswer = "9,999.99"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
   val form = new HowMuchCarersAllowanceForm(frontendAppConfig)()
-  val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def viewAsString(form: Form[_] = form) = howMuchCarersAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, formPartialRetriever, scalate).toString
 

--- a/test/controllers/HowMuchEmploymentAndSupportAllowanceControllerSpec.scala
+++ b/test/controllers/HowMuchEmploymentAndSupportAllowanceControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions._
 import forms.HowMuchEmploymentAndSupportAllowanceForm
 import identifiers.HowMuchEmploymentAndSupportAllowanceId
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.libs.json.JsString
@@ -35,8 +35,8 @@ class HowMuchEmploymentAndSupportAllowanceControllerSpec extends ControllerSpecB
 
   private val testAnswer = "9,999.99"
   private val form = new HowMuchEmploymentAndSupportAllowanceForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def onwardRoute = routes.IndexController.onPageLoad()
 

--- a/test/controllers/HowMuchForeignIncomeControllerSpec.scala
+++ b/test/controllers/HowMuchForeignIncomeControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchForeignIncomeForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -35,8 +35,8 @@ class HowMuchForeignIncomeControllerSpec extends ControllerSpecBase with Mockito
 
   val testAnswer = "9,999.99"
   val form = new HowMuchForeignIncomeForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new HowMuchForeignIncomeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/HowMuchFuelBenefitControllerSpec.scala
+++ b/test/controllers/HowMuchFuelBenefitControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchFuelBenefitForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -35,8 +35,8 @@ class HowMuchFuelBenefitControllerSpec extends ControllerSpecBase with MockitoSu
 
   val testAnswer = "9,999.99"
   val form = new HowMuchFuelBenefitForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new HowMuchFuelBenefitController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/HowMuchIncapacityBenefitControllerSpec.scala
+++ b/test/controllers/HowMuchIncapacityBenefitControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchIncapacityBenefitForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -32,8 +32,8 @@ class HowMuchIncapacityBenefitControllerSpec extends ControllerSpecBase {
 
   private val testAnswer = "9,999.99"
   private val form = new HowMuchIncapacityBenefitForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def onwardRoute = routes.IndexController.onPageLoad()
 

--- a/test/controllers/HowMuchInvestmentOrDividendControllerSpec.scala
+++ b/test/controllers/HowMuchInvestmentOrDividendControllerSpec.scala
@@ -23,7 +23,7 @@ import controllers.actions._
 import play.api.test.Helpers._
 import forms.HowMuchInvestmentOrDividendForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import views.html.howMuchInvestmentOrDividend
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -37,8 +37,8 @@ class HowMuchInvestmentOrDividendControllerSpec extends ControllerSpecBase {
       frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), messagesControllerComponents, new HowMuchInvestmentOrDividendForm(frontendAppConfig), formPartialRetriever, scalate)
 
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
-  private val taxYear = CYMinus2
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
+  private val taxYear = CustomTaxYear(2017)
   val testAnswer = "9,999.99"
   val form = new HowMuchInvestmentOrDividendForm(frontendAppConfig)()
 
@@ -47,7 +47,7 @@ class HowMuchInvestmentOrDividendControllerSpec extends ControllerSpecBase {
   "HowMuchInvestmentOrDividend Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller(someData).onPageLoad(NormalMode)(fakeRequest)
+      val result = controller(someData()).onPageLoad(NormalMode)(fakeRequest)
 
       status(result) mustBe OK
       contentAsString(result) mustBe viewAsString()

--- a/test/controllers/HowMuchJobseekersAllowanceControllerSpec.scala
+++ b/test/controllers/HowMuchJobseekersAllowanceControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchJobseekersAllowanceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -33,8 +33,8 @@ class HowMuchJobseekersAllowanceControllerSpec extends ControllerSpecBase {
 
   private val testAnswer = "9,999.99"
   private val form = new HowMuchJobseekersAllowanceForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def onwardRoute = routes.IndexController.onPageLoad()
 

--- a/test/controllers/HowMuchMedicalBenefitsControllerSpec.scala
+++ b/test/controllers/HowMuchMedicalBenefitsControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchMedicalBenefitsForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -32,8 +32,8 @@ class HowMuchMedicalBenefitsControllerSpec extends ControllerSpecBase {
 
   private val testAnswer = "9,999.99"
   private val form = new HowMuchMedicalBenefitsForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def onwardRoute = routes.IndexController.onPageLoad()
 

--- a/test/controllers/HowMuchRentalIncomeControllerSpec.scala
+++ b/test/controllers/HowMuchRentalIncomeControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchRentalIncomeForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -34,8 +34,8 @@ class HowMuchRentalIncomeControllerSpec extends ControllerSpecBase {
 
   val testAnswer = "9,999.99"
   val form = new HowMuchRentalIncomeForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new HowMuchRentalIncomeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/HowMuchStatePensionControllerSpec.scala
+++ b/test/controllers/HowMuchStatePensionControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.HowMuchStatePensionForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -33,8 +33,8 @@ class HowMuchStatePensionControllerSpec extends ControllerSpecBase {
 
   private val testAnswer = "9,999.99"
   private val form = new HowMuchStatePensionForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def onwardRoute = routes.IndexController.onPageLoad()
 

--- a/test/controllers/IsPaymentAddressInTheUKControllerSpec.scala
+++ b/test/controllers/IsPaymentAddressInTheUKControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.{AddressLookupConnector, FakeDataCacheConnector}
 import controllers.actions._
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -39,8 +39,8 @@ class IsPaymentAddressInTheUKControllerSpec extends ControllerSpecBase with Mock
   val formProvider = new BooleanForm()
   val form = formProvider()
   private val mockAddressLookup = mock[AddressLookupConnector]
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new IsPaymentAddressInTheUKController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/NomineeFullNameControllerSpec.scala
+++ b/test/controllers/NomineeFullNameControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.NomineeFullNameForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.data.Form
 import play.api.mvc.Call
@@ -39,8 +39,8 @@ class NomineeFullNameControllerSpec extends ControllerSpecBase {
 
   private val testAnswer = "answer"
   private val testTooLongAnswer = "A" * (frontendAppConfig.nomineeFullNameMaxLength + 1)
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
   val form = new NomineeFullNameForm(frontendAppConfig)()
 
   def viewAsString(form: Form[_] = form) =

--- a/test/controllers/OtherBenefitControllerSpec.scala
+++ b/test/controllers/OtherBenefitControllerSpec.scala
@@ -23,7 +23,7 @@ import controllers.actions._
 import play.api.test.Helpers._
 import forms.OtherBenefitForm
 import models.{Index, NormalMode, OtherBenefit}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.mvc.Call
 import views.html.otherBenefit
@@ -36,8 +36,8 @@ class OtherBenefitControllerSpec extends ControllerSpecBase {
   val testAnswer = OtherBenefit("qwerty", "123")
   val form = new OtherBenefitForm(frontendAppConfig)(Seq.empty, 0)
   val formFilled = new OtherBenefitForm(frontendAppConfig)(Seq.empty, 1)
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new OtherBenefitController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/OtherCompanyBenefitControllerSpec.scala
+++ b/test/controllers/OtherCompanyBenefitControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.OtherCompanyBenefitForm
 import models.{Index, NormalMode, OtherCompanyBenefit}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -36,8 +36,8 @@ class OtherCompanyBenefitControllerSpec extends ControllerSpecBase with MockitoS
   val testAnswer = OtherCompanyBenefit("qwerty", "123")
   val form = new OtherCompanyBenefitForm(messagesApi, frontendAppConfig)(Seq.empty, 0)
   val formFilled = new OtherCompanyBenefitForm(messagesApi, frontendAppConfig)(Seq.empty, 1)
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new OtherCompanyBenefitController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/OtherTaxableIncomeControllerSpec.scala
+++ b/test/controllers/OtherTaxableIncomeControllerSpec.scala
@@ -23,7 +23,7 @@ import controllers.actions._
 import play.api.test.Helpers._
 import forms.OtherTaxableIncomeForm
 import models.{AnyTaxPaid, Index, NormalMode, OtherTaxableIncome}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import play.api.mvc.Call
 import views.html.otherTaxableIncome
@@ -35,8 +35,8 @@ class OtherTaxableIncomeControllerSpec extends ControllerSpecBase {
 
   val testAnswer = OtherTaxableIncome("answer", "123", Some(AnyTaxPaid.Yes("123")))
   val form = new OtherTaxableIncomeForm(frontendAppConfig)(Seq.empty, 0)
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new OtherTaxableIncomeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/PaymentAddressCorrectControllerSpec.scala
+++ b/test/controllers/PaymentAddressCorrectControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.requests.{AuthenticatedRequest, OptionalDataRequest}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -39,8 +39,8 @@ class PaymentAddressCorrectControllerSpec extends ControllerSpecBase {
 
   val formProvider = new BooleanForm()
   val form = formProvider()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new PaymentAddressCorrectController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
@@ -57,7 +57,7 @@ class PaymentAddressCorrectControllerSpec extends ControllerSpecBase {
           nino = "AB123456A",
           name = Some(ItmpName(Some("sdadsad"), None, None)),
           address = itmpAddress,
-          userAnswers = Some(MockUserAnswers.claimDetailsUserAnswers))
+          userAnswers = Some(MockUserAnswers.claimDetailsUserAnswers()))
       )
     }
   }

--- a/test/controllers/PaymentInternationalAddressControllerSpec.scala
+++ b/test/controllers/PaymentInternationalAddressControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.PaymentInternationalAddressForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{InternationalAddress, NormalMode}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -37,8 +37,8 @@ class PaymentInternationalAddressControllerSpec extends ControllerSpecBase {
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), messagesControllerComponents, new PaymentInternationalAddressForm(frontendAppConfig), formPartialRetriever, scalate)
 
   val form = new PaymentInternationalAddressForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def viewAsString(form: Form[InternationalAddress] = form) =
     paymentInternationalAddress(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, formPartialRetriever, scalate).toString

--- a/test/controllers/PaymentUKAddressControllerSpec.scala
+++ b/test/controllers/PaymentUKAddressControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.PaymentUKAddressForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{NormalMode, UkAddress}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -37,8 +37,8 @@ class PaymentUKAddressControllerSpec extends ControllerSpecBase {
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), messagesControllerComponents, new PaymentUKAddressForm(frontendAppConfig), formPartialRetriever, scalate)
 
   val form = new PaymentUKAddressForm(frontendAppConfig)()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def viewAsString(form: Form[UkAddress] = form) =
     paymentUKAddress(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, formPartialRetriever, scalate).toString

--- a/test/controllers/RemoveOtherSelectedOptionControllerSpec.scala
+++ b/test/controllers/RemoveOtherSelectedOptionControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.BooleanForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{NormalMode, OtherBenefit}
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
@@ -37,8 +37,8 @@ class RemoveOtherSelectedOptionControllerSpec extends ControllerSpecBase with Mo
   val formProvider = new BooleanForm()
   val form = formProvider()
 
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.benefitsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.benefitsUserAnswers()
   private val collectionId = OtherBenefit.collectionId
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =

--- a/test/controllers/SelectBenefitsControllerSpec.scala
+++ b/test/controllers/SelectBenefitsControllerSpec.scala
@@ -22,7 +22,7 @@ import connectors.FakeDataCacheConnector
 import controllers.actions._
 import play.api.test.Helpers._
 import forms.SelectBenefitsForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{Benefits, NormalMode}
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito.when
@@ -33,8 +33,8 @@ class SelectBenefitsControllerSpec extends ControllerSpecBase with MockitoSugar 
 
   def onwardRoute = routes.IndexController.onPageLoad()
 
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new SelectBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/SelectCompanyBenefitsControllerSpec.scala
+++ b/test/controllers/SelectCompanyBenefitsControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.SelectCompanyBenefitsForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{CompanyBenefits, NormalMode}
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -33,8 +33,8 @@ class SelectCompanyBenefitsControllerSpec extends ControllerSpecBase with Mockit
 
   def onwardRoute = routes.IndexController.onPageLoad()
 
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new SelectCompanyBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/SelectTaxableIncomeControllerSpec.scala
+++ b/test/controllers/SelectTaxableIncomeControllerSpec.scala
@@ -23,7 +23,7 @@ import controllers.actions._
 import forms.SelectTaxableIncomeForm
 import play.api.test.Helpers._
 import models.{NormalMode, TaxableIncome}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.mockito.Mockito.when
 import views.html.selectTaxableIncome
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,8 +32,8 @@ class SelectTaxableIncomeControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.IndexController.onPageLoad()
 
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.claimDetailsUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new SelectTaxableIncomeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/TelephoneNumberControllerSpec.scala
+++ b/test/controllers/TelephoneNumberControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors._
 import controllers.actions._
 import forms.TelephoneNumberForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models._
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
@@ -39,8 +39,8 @@ class TelephoneNumberControllerSpec extends ControllerSpecBase with MockitoSugar
   private val testAnswer = "0191 111 1111"
   private val formProvider = new TelephoneNumberForm()
   private val form = formProvider()
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new TelephoneNumberController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),

--- a/test/controllers/WhereToSendPaymentControllerSpec.scala
+++ b/test/controllers/WhereToSendPaymentControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FakeDataCacheConnector
 import controllers.actions._
 import forms.WhereToSendPaymentForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{NormalMode, WhereToSendPayment}
 import org.mockito.Mockito.when
 import play.api.data.Form
@@ -30,8 +30,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class WhereToSendPaymentControllerSpec extends ControllerSpecBase {
 
-  private val taxYear = CYMinus2
-  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers
+  private val taxYear = CustomTaxYear(2017)
+  private val mockUserAnswers = MockUserAnswers.minimalValidUserAnswers()
 
   def onwardRoute = routes.IndexController.onPageLoad()
 

--- a/test/models/templates/RobotsSpec.scala
+++ b/test/models/templates/RobotsSpec.scala
@@ -28,7 +28,7 @@ import scala.xml._
 class RobotsSpec extends SpecBase {
   val robotXML = new RobotXML
 
-  private val fullUserAnswers: UserAnswers = MockUserAnswers.fullValidUserAnswers
+  private val fullUserAnswers: UserAnswers = MockUserAnswers.fullValidUserAnswers(2016)
 
   private val submissionReference: String = "1234"
   private val timeStamp: String = "1234567890"
@@ -73,7 +73,7 @@ class RobotsSpec extends SpecBase {
           </itmpAddress>
         </userDetails>
         <claimSection>
-          <selectedTaxYear>6 April 2017 to 5 April 2018</selectedTaxYear>
+          <selectedTaxYear>6 April 2016 to 5 April 2017</selectedTaxYear>
           <employmentDetails>true</employmentDetails>
         </claimSection>
         <benefitSection>
@@ -125,7 +125,7 @@ class RobotsSpec extends SpecBase {
     }
 
     "have correct sections in claimSection when employmentDetails are true" in {
-      fullXml \ "claimSection" \ "selectedTaxYear" must contain(<selectedTaxYear>6 April 2017 to 5 April 2018</selectedTaxYear>)
+      fullXml \ "claimSection" \ "selectedTaxYear" must contain(<selectedTaxYear>6 April 2016 to 5 April 2017</selectedTaxYear>)
       fullXml \ "claimSection" \ "employmentDetails" must contain(<employmentDetails>true</employmentDetails>)
     }
 
@@ -137,7 +137,7 @@ class RobotsSpec extends SpecBase {
 
       val newXmlToNode = formatXml(fullUserAnswers)
 
-      newXmlToNode \ "claimSection" \ "selectedTaxYear"  must contain(<selectedTaxYear>6 April 2017 to 5 April 2018</selectedTaxYear>)
+      newXmlToNode \ "claimSection" \ "selectedTaxYear"  must contain(<selectedTaxYear>6 April 2016 to 5 April 2017</selectedTaxYear>)
       newXmlToNode \ "claimSection" \ "employmentDetails" must contain(<employmentDetails>false</employmentDetails>)
       newXmlToNode \ "claimSection" \ "payeReference" must contain(<payeReference>123456789</payeReference>)
       newXmlToNode \ "claimSection" \ "detailsOfEmploymentOrPension" must contain(<detailsOfEmploymentOrPension>Employment details</detailsOfEmploymentOrPension>)
@@ -310,7 +310,7 @@ class RobotsSpec extends SpecBase {
     }
 
     "minimal valid answers must form correctly" in {
-      val xml: Node = formatXml(MockUserAnswers.minimalValidUserAnswers)
+      val xml: Node = formatXml(MockUserAnswers.minimalValidUserAnswers(2016))
 
       xml mustBe validMinimalXml
     }

--- a/test/utils/BenefitsNavigatorSpec.scala
+++ b/test/utils/BenefitsNavigatorSpec.scala
@@ -40,7 +40,7 @@ class BenefitsNavigatorSpec extends SpecBase with MockitoSugar {
       }
 
       "go to otherBenefit if there is no previous otherBenefit" in {
-        val answers = MockUserAnswers.benefitsUserAnswers
+        val answers = MockUserAnswers.benefitsUserAnswers()
         navigator.nextPage(OtherBenefitId, NormalMode)(answers) mustBe routes.AnyOtherBenefitsController.onPageLoad(NormalMode)
       }
 
@@ -296,7 +296,7 @@ class BenefitsNavigatorSpec extends SpecBase with MockitoSugar {
         }
 
         "take you to SelectBenefits from AnyBenefits when Yes is selected and no company benefits selected" in {
-          val answers = MockUserAnswers.benefitsUserAnswers
+          val answers = MockUserAnswers.benefitsUserAnswers()
           when(answers.anyBenefits) thenReturn Some(true)
           when(answers.selectBenefits) thenReturn None
           navigator.nextPage(AnyBenefitsId, CheckMode)(answers) mustBe routes.SelectBenefitsController.onPageLoad(CheckMode)
@@ -347,12 +347,12 @@ class BenefitsNavigatorSpec extends SpecBase with MockitoSugar {
 
       "Navigating from OtherBenefitsName" must {
         "go to AnyOtherBenefitsController when name and amount stored" in {
-          val answers = MockUserAnswers.benefitsUserAnswers
+          val answers = MockUserAnswers.benefitsUserAnswers()
           navigator.nextPage(OtherBenefitId, CheckMode)(answers) mustBe routes.AnyOtherBenefitsController.onPageLoad(CheckMode)
         }
 
         "go to AnyOtherBenefitsController when no amount stored" in {
-          val answers = MockUserAnswers.benefitsUserAnswers
+          val answers = MockUserAnswers.benefitsUserAnswers()
           when(answers.anyOtherBenefits) thenReturn None
 
           navigator.nextPage(OtherBenefitId, CheckMode)(answers) mustBe routes.AnyOtherBenefitsController.onPageLoad(CheckMode)
@@ -361,13 +361,13 @@ class BenefitsNavigatorSpec extends SpecBase with MockitoSugar {
 
       "Navigating from AnyOtherBenefit" must {
         "in CheckMode go to CheckYourAnswersController when amount stored and add another benefit is false" in {
-          val answers = MockUserAnswers.benefitsUserAnswers
+          val answers = MockUserAnswers.benefitsUserAnswers()
           when(answers.anyOtherBenefits) thenReturn Some(false)
           navigator.nextPage(AnyOtherBenefitsId, CheckMode)(answers) mustBe routes.CheckYourAnswersController.onPageLoad()
         }
 
         "in CheckMode go to OtherBenefits when add another benefit is true" in {
-          val answers = MockUserAnswers.benefitsUserAnswers
+          val answers = MockUserAnswers.benefitsUserAnswers()
           when(answers.anyOtherBenefits) thenReturn Some(true)
           navigator.nextPage(AnyOtherBenefitsId, CheckMode)(answers) mustBe routes.OtherBenefitController.onPageLoad(CheckMode, 3)
         }

--- a/test/utils/CheckYourAnswersSectionsSpec.scala
+++ b/test/utils/CheckYourAnswersSectionsSpec.scala
@@ -29,7 +29,7 @@ class CheckYourAnswersSectionsSpec extends SpecBase with MockitoSugar with Befor
 
 
   "sections have correct label" must {
-    val answers = MockUserAnswers.minimalValidUserAnswers
+    val answers = MockUserAnswers.minimalValidUserAnswers()
     val helper = new CheckYourAnswersHelper(answers)(messages: Messages)
     val sections = new CheckYourAnswersSections(helper, answers)
 
@@ -60,7 +60,7 @@ class CheckYourAnswersSectionsSpec extends SpecBase with MockitoSugar with Befor
 
   "all questions are answered and have the correct rows in the right order" must {
     "Claim details section" in {
-      val answers = MockUserAnswers.claimDetailsUserAnswers
+      val answers = MockUserAnswers.claimDetailsUserAnswers()
       val helper = new CheckYourAnswersHelper(answers)(messages: Messages)
       val sections = new CheckYourAnswersSections(helper, answers)
       val rows = sections.claimSection.rows
@@ -73,7 +73,7 @@ class CheckYourAnswersSectionsSpec extends SpecBase with MockitoSugar with Befor
     }
 
     "Benefits section" in {
-      val answers = MockUserAnswers.benefitsUserAnswers
+      val answers = MockUserAnswers.benefitsUserAnswers()
       val helper = new CheckYourAnswersHelper(answers)(messages: Messages)
       val sections = new CheckYourAnswersSections(helper, answers)
       val rows: Seq[AnswerRow] = sections.benefitSection.rows
@@ -204,7 +204,7 @@ class CheckYourAnswersSectionsSpec extends SpecBase with MockitoSugar with Befor
     }
 
     "Other Benefits section normal mode" in {
-      val answers = MockUserAnswers.fullValidUserAnswers
+      val answers = MockUserAnswers.fullValidUserAnswers()
       val helper = new CheckYourAnswersHelper(answers)(messages: Messages)
       val sections = new CheckYourAnswersSections(helper, answers)
       val normalModeRows = sections.otherBenefitsAddToListNormalMode.rows

--- a/test/utils/EnumerableSpec.scala
+++ b/test/utils/EnumerableSpec.scala
@@ -30,6 +30,8 @@ object EnumerableSpec {
 
   object Foo extends Enumerable[Foo] {
     override def values: Set[Foo] = Set(Bar, Baz)
+
+    override def harnessReads: PartialFunction[Any, Nothing] = PartialFunction.empty
   }
 
 }

--- a/test/utils/MockUserAnswers.scala
+++ b/test/utils/MockUserAnswers.scala
@@ -16,12 +16,13 @@
 
 package utils
 
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.{CYMinus2, CustomTaxYear}
 import models.WhereToSendPayment.{Myself, Nominee}
 import models.{Metadata, _}
 import org.joda.time.LocalDateTime
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.Messages
 import uk.gov.hmrc.auth.core.retrieve.{ItmpAddress, ItmpName}
 
 object MockUserAnswers extends MockitoSugar {
@@ -91,7 +92,7 @@ object MockUserAnswers extends MockitoSugar {
     answers
   }
 
-  def minimalValidUserAnswers: UserAnswers = {
+  def minimalValidUserAnswers(year: Int = 2017): UserAnswers = {
     val answers = nothingAnswered
     val metadata: Metadata = new Metadata(customerId = "ZZ123456A", "123", "123", LocalDateTime.now(), "", "en")
 
@@ -109,7 +110,7 @@ object MockUserAnswers extends MockitoSugar {
         Some("GB")
       ))
 
-    when(answers.selectTaxYear) thenReturn Some(CYMinus2)
+    when(answers.selectTaxYear) thenReturn Some(CustomTaxYear(year))
     when(answers.employmentDetails) thenReturn Some(true)
     when(answers.anyBenefits) thenReturn Some(false)
     when(answers.anyCompanyBenefits) thenReturn Some(false)
@@ -126,10 +127,10 @@ object MockUserAnswers extends MockitoSugar {
     answers
   }
 
-  def claimDetailsUserAnswers: UserAnswers = {
+  def claimDetailsUserAnswers(year: Int = 2017): UserAnswers = {
     val answers = nothingAnswered
 
-    when(answers.selectTaxYear) thenReturn Some(CYMinus2)
+    when(answers.selectTaxYear) thenReturn Some(CustomTaxYear(year))
     when(answers.employmentDetails) thenReturn Some(false)
     when(answers.enterPayeReference) thenReturn Some("AB12345")
     when(answers.detailsOfEmploymentOrPension) thenReturn Some("Details of employment")
@@ -137,10 +138,10 @@ object MockUserAnswers extends MockitoSugar {
     answers
   }
 
-  def benefitsUserAnswers: UserAnswers = {
+  def benefitsUserAnswers(year: Int = 2017): UserAnswers = {
     val answers = nothingAnswered
 
-    when(answers.selectTaxYear) thenReturn Some(CYMinus2)
+    when(answers.selectTaxYear) thenReturn Some(CustomTaxYear(year))
     when(answers.anyBenefits) thenReturn Some(true)
     when(answers.selectBenefits) thenReturn Some(
       Seq(Benefits.CARERS_ALLOWANCE,
@@ -251,7 +252,7 @@ object MockUserAnswers extends MockitoSugar {
     answers
   }
 
-  def fullValidUserAnswers: UserAnswers = {
+  def fullValidUserAnswers(year: Int = 2017): UserAnswers = {
     val answers = nothingAnswered
 
     val metadata = new Metadata(customerId = "ZZ123456A", "123", "123", LocalDateTime.now(), "", "en")
@@ -270,7 +271,7 @@ object MockUserAnswers extends MockitoSugar {
         Some("GB")
       ))
 
-    when(answers.selectTaxYear) thenReturn Some(CYMinus2)
+    when(answers.selectTaxYear) thenReturn Some(CustomTaxYear(year))
     when(answers.employmentDetails) thenReturn Some(true)
 
     when(answers.anyBenefits) thenReturn Some(true)

--- a/test/utils/NavigatorSpec.scala
+++ b/test/utils/NavigatorSpec.scala
@@ -19,7 +19,7 @@ package utils
 import base.SpecBase
 import controllers.routes
 import identifiers._
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.WhereToSendPayment.{Myself, Nominee}
 import models._
 import org.mockito.Mockito._
@@ -379,13 +379,13 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
       //Claim details section
 
       "go to Employment details from SelectTaxYear if Employment details is empty" in {
-        when(answers.selectTaxYear) thenReturn Some(CYMinus2)
+        when(answers.selectTaxYear) thenReturn Some(CustomTaxYear(2017))
         when(answers.employmentDetails) thenReturn None
         navigator.nextPage(SelectTaxYearId, CheckMode)(answers) mustBe routes.EmploymentDetailsController.onPageLoad(CheckMode)
       }
 
       "got to CYA from SelectTaxYear if Employment details is not empty" in {
-        when(answers.selectTaxYear) thenReturn Some(CYMinus2)
+        when(answers.selectTaxYear) thenReturn Some(CustomTaxYear(2017))
         when(answers.employmentDetails) thenReturn Some(true)
         navigator.nextPage(SelectTaxYearId, CheckMode)(answers) mustBe routes.CheckYourAnswersController.onPageLoad()
       }

--- a/test/views/AnyBenefitsViewSpec.scala
+++ b/test/views/AnyBenefitsViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.YesNoViewBehaviours
@@ -29,7 +29,7 @@ class AnyBenefitsViewSpec extends YesNoViewBehaviours {
 
   private val messageKeyPrefix = "anyBenefits"
   private val listMessageKeyPrefix = "selectBenefits"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form = new BooleanForm()()
 

--- a/test/views/AnyCompanyBenefitsViewSpec.scala
+++ b/test/views/AnyCompanyBenefitsViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import play.api.data.Form
 import views.behaviours.YesNoViewBehaviours
 import views.html.anyCompanyBenefits
@@ -28,7 +28,7 @@ class AnyCompanyBenefitsViewSpec extends YesNoViewBehaviours {
 
   private val messageKeyPrefix = "anyCompanyBenefits"
   private val listMessageKeyPrefix = "selectCompanyBenefits"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form = new BooleanForm()()
 

--- a/test/views/AnyOtherBenefitsViewSpec.scala
+++ b/test/views/AnyOtherBenefitsViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.twirl.api.Html
@@ -31,10 +31,10 @@ import views.html.anyOtherBenefits
 class AnyOtherBenefitsViewSpec extends YesNoViewBehaviours {
 
   private val messageKeyPrefix = "anyOtherBenefits"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
-	private val cya: CheckYourAnswersHelper = new CheckYourAnswersHelper(MockUserAnswers.fullValidUserAnswers)(messages)
-	private val otherBenefits: AnswerSection = new CheckYourAnswersSections(cya, MockUserAnswers.fullValidUserAnswers).otherBenefitsAddToListNormalMode
+	private val cya: CheckYourAnswersHelper = new CheckYourAnswersHelper(MockUserAnswers.fullValidUserAnswers())(messages)
+	private val otherBenefits: AnswerSection = new CheckYourAnswersSections(cya, MockUserAnswers.fullValidUserAnswers()).otherBenefitsAddToListNormalMode
 
   override val form = new BooleanForm()()
 

--- a/test/views/AnyOtherCompanyBenefitsViewSpec.scala
+++ b/test/views/AnyOtherCompanyBenefitsViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.twirl.api.Html
@@ -31,10 +31,10 @@ import views.html.anyOtherCompanyBenefits
 class AnyOtherCompanyBenefitsViewSpec extends YesNoViewBehaviours {
 
 	private val messageKeyPrefix = "anyOtherCompanyBenefits"
-	private val taxYear = CYMinus2
+	private val taxYear = CustomTaxYear(2017)
 
-	private val cya: CheckYourAnswersHelper = new CheckYourAnswersHelper(MockUserAnswers.fullValidUserAnswers)(messages)
-	private val otherCompanyBenefits: AnswerSection = new CheckYourAnswersSections(cya, MockUserAnswers.fullValidUserAnswers).otherCompanyBenefitsAddToListNormalMode
+	private val cya: CheckYourAnswersHelper = new CheckYourAnswersHelper(MockUserAnswers.fullValidUserAnswers())(messages)
+	private val otherCompanyBenefits: AnswerSection = new CheckYourAnswersSections(cya, MockUserAnswers.fullValidUserAnswers()).otherCompanyBenefitsAddToListNormalMode
 
 	override val form = new BooleanForm()()
 

--- a/test/views/AnyOtherTaxableIncomeViewSpec.scala
+++ b/test/views/AnyOtherTaxableIncomeViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.{AnyTaxPaid, NormalMode, OtherTaxableIncome}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
@@ -29,7 +29,7 @@ import views.html.anyOtherTaxableIncome
 class AnyOtherTaxableIncomeViewSpec extends YesNoViewBehaviours {
 
 	private val messageKeyPrefix = "anyOtherTaxableIncome"
-	private val taxYear = CYMinus2
+	private val taxYear = CustomTaxYear(2017)
 
 	val completeSeq: Seq[(OtherTaxableIncome, Int)] = Seq((OtherTaxableIncome("qwerty1", "1234", Some(AnyTaxPaid.Yes("1234"))), 0))
 	val incompleteSeq: Seq[(OtherTaxableIncome, Int)] = Seq((OtherTaxableIncome("qwerty2", "1234", None), 1))

--- a/test/views/AnyTaxableBankInterestViewSpec.scala
+++ b/test/views/AnyTaxableBankInterestViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.AnyTaxPaidForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
@@ -32,7 +32,7 @@ class AnyTaxableBankInterestViewSpec extends QuestionViewBehaviours[AnyTaxPaid] 
   private val notSelectedKey = "anyTaxableBankInterest.notSelected"
   private val blankKey = "anyTaxableBankInterest.blank"
   private val invalidKey = "anyTaxableBankInterest.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm()
   val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/views/AnyTaxableForeignIncomeViewSpec.scala
+++ b/test/views/AnyTaxableForeignIncomeViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.AnyTaxPaidForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
@@ -32,7 +32,7 @@ class AnyTaxableForeignIncomeViewSpec extends QuestionViewBehaviours[AnyTaxPaid]
   private val notSelectedKey = "anyTaxableForeignIncome.notSelected"
   private val blankKey = "anyTaxableForeignIncome.blank"
   private val invalidKey = "anyTaxableForeignIncome.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm()
   val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/views/AnyTaxableIncomeViewSpec.scala
+++ b/test/views/AnyTaxableIncomeViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.YesNoViewBehaviours
@@ -29,7 +29,7 @@ class AnyTaxableIncomeViewSpec extends YesNoViewBehaviours {
 
   private val messageKeyPrefix = "anyTaxableIncome"
   private val listMessageKeyPrefix = "selectTaxableIncome"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form = new BooleanForm()()
 

--- a/test/views/AnyTaxableInvestmentsViewSpec.scala
+++ b/test/views/AnyTaxableInvestmentsViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.AnyTaxPaidForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
@@ -32,7 +32,7 @@ class AnyTaxableInvestmentsViewSpec extends QuestionViewBehaviours[AnyTaxPaid] {
   private val notSelectedKey = "anyTaxableInvestments.notSelected"
   private val blankKey = "anyTaxableInvestments.blank"
   private val invalidKey = "anyTaxableInvestments.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm()
   val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/views/AnyTaxableOtherIncomeViewSpec.scala
+++ b/test/views/AnyTaxableOtherIncomeViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.AnyTaxPaidForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
@@ -32,7 +32,7 @@ class AnyTaxableOtherIncomeViewSpec extends QuestionViewBehaviours[AnyTaxPaid] {
   private val notSelectedKey = "anyTaxableOtherIncome.notSelected"
   private val blankKey = "anyTaxableOtherIncome.blank"
   private val invalidKey = "anyTaxableOtherIncome.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
   private val incomeName = "test income"
 
   val formProvider = new AnyTaxPaidForm()

--- a/test/views/AnyTaxableRentalIncomeViewSpec.scala
+++ b/test/views/AnyTaxableRentalIncomeViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.AnyTaxPaidForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{AnyTaxPaid, NormalMode}
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
@@ -32,7 +32,7 @@ class AnyTaxableRentalIncomeViewSpec extends QuestionViewBehaviours[AnyTaxPaid] 
   private val notSelectedKey = "anyTaxableRentalIncome.notSelected"
   private val blankKey = "anyTaxableRentalIncome.blank"
   private val invalidKey = "anyTaxableRentalIncome.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val formProvider = new AnyTaxPaidForm()
   val form = formProvider(notSelectedKey, blankKey, invalidKey)

--- a/test/views/CheckYourAnswersViewSpec.scala
+++ b/test/views/CheckYourAnswersViewSpec.scala
@@ -26,7 +26,7 @@ import views.html.check_your_answers
 class CheckYourAnswersViewSpec extends SpecBase with ViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "checkYourAnswers"
-  private val answers = MockUserAnswers.fullValidUserAnswers
+  private val answers = MockUserAnswers.fullValidUserAnswers()
   private val helper = new CheckYourAnswersHelper(answers)(messages: Messages)
   private val cyaSection = new CheckYourAnswersSections(helper, answers)
   private val sections = cyaSection.sections

--- a/test/views/DetailsOfEmploymentOrPensionViewSpec.scala
+++ b/test/views/DetailsOfEmploymentOrPensionViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.DetailsOfEmploymentOrPensionForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.detailsOfEmploymentOrPension
 class DetailsOfEmploymentOrPensionViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "detailsOfEmploymentOrPension"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
   private val characterLimit = 500
 
   override val form: Form[String] = new DetailsOfEmploymentOrPensionForm(frontendAppConfig)()

--- a/test/views/EmploymentDetailsViewSpec.scala
+++ b/test/views/EmploymentDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.BooleanForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{Employment, NormalMode}
 import play.api.data.Form
 import views.behaviours.YesNoViewBehaviours
@@ -29,7 +29,7 @@ class EmploymentDetailsViewSpec extends YesNoViewBehaviours {
   private val messageKeyPrefix = "employmentDetails"
   private val hintTextKey = "employmentDetails.hintText"
   private val fakeEmployments = Seq(Employment("AVIVA PENSIONS", "754", "AZ00070"))
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form = new BooleanForm()()
 

--- a/test/views/HowMuchBankInterestViewSpec.scala
+++ b/test/views/HowMuchBankInterestViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchBankInterestForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchBankInterest
 class HowMuchBankInterestViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchBankInterest"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchBankInterestForm(frontendAppConfig)()
 

--- a/test/views/HowMuchBereavementAllowanceViewSpec.scala
+++ b/test/views/HowMuchBereavementAllowanceViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchBereavementAllowanceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchBereavementAllowance
 class HowMuchBereavementAllowanceViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchBereavementAllowance"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchBereavementAllowanceForm(frontendAppConfig)()
 

--- a/test/views/HowMuchCarBenefitsViewSpec.scala
+++ b/test/views/HowMuchCarBenefitsViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchCarBenefitsForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchCarBenefits
 class HowMuchCarBenefitsViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchCarBenefits"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchCarBenefitsForm(frontendAppConfig)()
 

--- a/test/views/HowMuchCarersAllowanceViewSpec.scala
+++ b/test/views/HowMuchCarersAllowanceViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchCarersAllowanceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchCarersAllowance
 class HowMuchCarersAllowanceViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchCarersAllowance"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchCarersAllowanceForm(frontendAppConfig)()
 

--- a/test/views/HowMuchEmploymentAndSupportAllowanceViewSpec.scala
+++ b/test/views/HowMuchEmploymentAndSupportAllowanceViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchEmploymentAndSupportAllowanceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchEmploymentAndSupportAllowance
 class HowMuchEmploymentAndSupportAllowanceViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchEmploymentAndSupportAllowance"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchEmploymentAndSupportAllowanceForm(frontendAppConfig)()
 

--- a/test/views/HowMuchForeignIncomeViewSpec.scala
+++ b/test/views/HowMuchForeignIncomeViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchForeignIncomeForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchForeignIncome
 class HowMuchForeignIncomeViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchForeignIncome"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchForeignIncomeForm(frontendAppConfig)()
 

--- a/test/views/HowMuchFuelBenefitViewSpec.scala
+++ b/test/views/HowMuchFuelBenefitViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchFuelBenefitForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchFuelBenefit
 class HowMuchFuelBenefitViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchFuelBenefit"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchFuelBenefitForm(frontendAppConfig)()
 

--- a/test/views/HowMuchIncapacityBenefitViewSpec.scala
+++ b/test/views/HowMuchIncapacityBenefitViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchIncapacityBenefitForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchIncapacityBenefit
 class HowMuchIncapacityBenefitViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchIncapacityBenefit"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchIncapacityBenefitForm(frontendAppConfig)()
 

--- a/test/views/HowMuchInvestmentOrDividendViewSpec.scala
+++ b/test/views/HowMuchInvestmentOrDividendViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchInvestmentOrDividendForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchInvestmentOrDividend
 class HowMuchInvestmentOrDividendViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchInvestmentOrDividend"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchInvestmentOrDividendForm(frontendAppConfig)()
 

--- a/test/views/HowMuchJobseekersAllowanceViewSpec.scala
+++ b/test/views/HowMuchJobseekersAllowanceViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchJobseekersAllowanceForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchJobseekersAllowance
 class HowMuchJobseekersAllowanceViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchJobseekersAllowance"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchJobseekersAllowanceForm(frontendAppConfig)()
 

--- a/test/views/HowMuchMedicalBenefitsViewSpec.scala
+++ b/test/views/HowMuchMedicalBenefitsViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchMedicalBenefitsForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchMedicalBenefits
 class HowMuchMedicalBenefitsViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchMedicalBenefits"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchMedicalBenefitsForm(frontendAppConfig)()
 

--- a/test/views/HowMuchRentalIncomeViewSpec.scala
+++ b/test/views/HowMuchRentalIncomeViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchRentalIncomeForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchRentalIncome
 class HowMuchRentalIncomeViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchRentalIncome"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchRentalIncomeForm(frontendAppConfig)()
 

--- a/test/views/HowMuchStatePensionViewSpec.scala
+++ b/test/views/HowMuchStatePensionViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.HowMuchStatePensionForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import views.behaviours.StringViewBehaviours
@@ -28,7 +28,7 @@ import views.html.howMuchStatePension
 class HowMuchStatePensionViewSpec extends StringViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "howMuchStatePension"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[String] = new HowMuchStatePensionForm(frontendAppConfig)()
 

--- a/test/views/IsPaymentAddressInTheUKViewSpec.scala
+++ b/test/views/IsPaymentAddressInTheUKViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.BooleanForm
 import models.NormalMode
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import play.api.data.Form
 import views.behaviours.YesNoViewBehaviours
 import views.html.isPaymentAddressInTheUK
@@ -27,7 +27,7 @@ import views.html.isPaymentAddressInTheUK
 class IsPaymentAddressInTheUKViewSpec extends YesNoViewBehaviours {
 
   val messageKeyPrefix = "isPaymentAddressInTheUK"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form = new BooleanForm()()
 

--- a/test/views/OtherBenefitViewSpec.scala
+++ b/test/views/OtherBenefitViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.OtherBenefitForm
 import models.{NormalMode, OtherBenefit}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
@@ -29,7 +29,7 @@ import views.html.otherBenefit
 class OtherBenefitViewSpec extends QuestionViewBehaviours[OtherBenefit] with MockitoSugar {
 
   private val messageKeyPrefix = "otherBenefit"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[OtherBenefit] = new OtherBenefitForm(frontendAppConfig)(Seq.empty, 0)
 

--- a/test/views/OtherCompanyBenefitViewSpec.scala
+++ b/test/views/OtherCompanyBenefitViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.routes
 import forms.OtherCompanyBenefitForm
 import models.{NormalMode, OtherCompanyBenefit}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
@@ -29,7 +29,7 @@ import views.html.otherCompanyBenefit
 class OtherCompanyBenefitViewSpec extends QuestionViewBehaviours[OtherCompanyBenefit] with MockitoSugar {
 
   private val messageKeyPrefix = "otherCompanyBenefit"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[OtherCompanyBenefit] = new OtherCompanyBenefitForm(messagesApi, frontendAppConfig)(Seq.empty, 0)
 

--- a/test/views/OtherTaxableIncomeViewSpec.scala
+++ b/test/views/OtherTaxableIncomeViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import controllers.routes
 import forms.OtherTaxableIncomeForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{NormalMode, OtherTaxableIncome}
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
@@ -29,7 +29,7 @@ import views.html.otherTaxableIncome
 class OtherTaxableIncomeViewSpec extends QuestionViewBehaviours[OtherTaxableIncome] with MockitoSugar {
 
   private val messageKeyPrefix = "otherTaxableIncome"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   override val form: Form[OtherTaxableIncome] = new OtherTaxableIncomeForm(frontendAppConfig)(Seq.empty, 0)
 

--- a/test/views/PdfCheckYourAnswersViewSpec.scala
+++ b/test/views/PdfCheckYourAnswersViewSpec.scala
@@ -30,7 +30,7 @@ import views.html.pdf_check_your_answers
 class PdfCheckYourAnswersViewSpec extends SpecBase with ViewBehaviours with MockitoSugar {
 
   private val messageKeyPrefix = "checkYourAnswers"
-  private val answers = MockUserAnswers.minimalValidUserAnswers
+  private val answers = MockUserAnswers.minimalValidUserAnswers()
   private val helper = new CheckYourAnswersHelper(answers)(messages: Messages)
   private val cyaSection = new CheckYourAnswersSections(helper, answers)
   private val sections = cyaSection.sections

--- a/test/views/RemoveOtherSelectedOptionViewSpec.scala
+++ b/test/views/RemoveOtherSelectedOptionViewSpec.scala
@@ -21,14 +21,14 @@ import controllers.routes
 import forms.BooleanForm
 import views.behaviours.YesNoViewBehaviours
 import models.{NormalMode, OtherBenefit}
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import play.twirl.api.Html
 import views.html.removeOtherSelectedOption
 
 class RemoveOtherSelectedOptionViewSpec extends YesNoViewBehaviours {
 
   private val messageKeyPrefix = "RemoveOtherSelectedOption"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
   private val collectionId = OtherBenefit.collectionId
 
   override val form = new BooleanForm()()

--- a/test/views/SelectBenefitsViewSpec.scala
+++ b/test/views/SelectBenefitsViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import forms.SelectBenefitsForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{Benefits, NormalMode}
 import play.api.data.Form
 import play.twirl.api.Html
@@ -29,7 +29,7 @@ class SelectBenefitsViewSpec extends ViewBehaviours with CheckboxViewBehaviours[
   val messageKeyPrefix = "selectBenefits"
   val fieldKey = "value"
   val errorMessage = "error.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val values: Seq[(String, String)] = SelectBenefitsForm.options
 

--- a/test/views/SelectCompanyBenefitsViewSpec.scala
+++ b/test/views/SelectCompanyBenefitsViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import forms.SelectCompanyBenefitsForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{CompanyBenefits, NormalMode}
 import play.api.data.Form
 import play.twirl.api.Html
@@ -29,7 +29,7 @@ class SelectCompanyBenefitsViewSpec extends ViewBehaviours with CheckboxViewBeha
   val messageKeyPrefix = "selectCompanyBenefits"
   val fieldKey = "value"
   val errorMessage = "error.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val values: Seq[(String, String)] = SelectCompanyBenefitsForm.options
 

--- a/test/views/SelectTaxableIncomeViewSpec.scala
+++ b/test/views/SelectTaxableIncomeViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import forms.SelectTaxableIncomeForm
-import models.SelectTaxYear.CYMinus2
+import models.SelectTaxYear.CustomTaxYear
 import models.{NormalMode, TaxableIncome}
 import play.api.data.Form
 import play.twirl.api.Html
@@ -29,7 +29,7 @@ class SelectTaxableIncomeViewSpec extends ViewBehaviours with CheckboxViewBehavi
   val messageKeyPrefix = "selectTaxableIncome"
   val fieldKey = "value"
   val errorMessage = "error.invalid"
-  private val taxYear = CYMinus2
+  private val taxYear = CustomTaxYear(2017)
 
   val values: Seq[(String, String)] = SelectTaxableIncomeForm.options
 


### PR DESCRIPTION
# DL-1810 Ensure unit tests use fixed dates

**Bug fix**

* Ensured unit tests always make use of hardcoded dates. This is to ensure unit tests are robust throughout each tax year and don't break in the future, requiring further maintenance.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
