### PR TITLE
DL-2686 - CTR Dependency Updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] =
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(Seq(play.sbt.PlayScala, PlayNettyServer, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(playSettings: _*)
   .settings(RoutesKeys.routesImport ++= Seq("models._"))
   .settings(


### PR DESCRIPTION
# DL-2686 - CTR Dependency Updates (JUnitXmlReportPlugin)

Disabled a plugin that was causing the build job to fail as 'Unstable'. Applied fix per https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=176632503

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
