### PR TITLE
DL-2686 - CTR Dependency Updates (Removed ScalaJS library exclusions)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,12 +8,6 @@ resolvers += "HMRC Artifactory Releases" at "https://artefacts.tax.service.gov.u
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-excludeDependencies ++= Seq(
-  ExclusionRule("io.monix", "monix_2.12"),
-  ExclusionRule("org.webjars", "envjs"),
-  ExclusionRule("org.webjars", "npm"),
-  ExclusionRule("com.google.javascript", "closure-compiler-externs"))
-
 libraryDependencies += "io.monix" %% "monix" % "2.3.3" pomOnly()
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")


### PR DESCRIPTION
# Removed ScalaJS library exclusions

Updating the sbt version to 1.3.7 prevented Intellij from successfully retrieving the source.jars for ScalaJS libraries. The project was unaffected, but this interfered with the editor's autocomplete. As a short term fix, these libraries were excluded, but importing the project into Intellij without retrieving the sources has solved the issue.  

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
