### PR TITLE
DL-2971 - CTR to pass accessibility statement URL to the address lookup service

### DIFF
--- a/app/config/AddressLookupConfig.scala
+++ b/app/config/AddressLookupConfig.scala
@@ -22,14 +22,14 @@ import play.api.libs.json.{JsObject, Json}
 
 class AddressLookupConfig @Inject()(messagesApi: MessagesApi) {
 
-  def config(continueUrl:String)(implicit language: Lang) = {
+  def config(continueUrl:String, accessibilityFooterUrl: String)(implicit language: Lang) = {
 
     val cy = Lang("CY")
-
     val v2Config = s"""{
                       |  "version": 2,
                       |  "options": {
                       |    "continueUrl": "$continueUrl",
+                      |    "accessibilityFooterUrl": "$accessibilityFooterUrl",
                       |    "phaseFeedbackLink": "/help/alpha",
                       |    "showPhaseBanner": false,
                       |    "alphaPhase": false,

--- a/app/connectors/AddressLookupConnector.scala
+++ b/app/connectors/AddressLookupConnector.scala
@@ -39,9 +39,9 @@ class AddressLookupConnector @Inject()(
                                         dataCacheConnector: DataCacheConnector
                                       ) {
 
-  def initialise(continueUrl: String)(implicit hc: HeaderCarrier, language: Lang): Future[Option[String]] = {
+  def initialise(continueUrl: String, accessibilityFooterUrl: String)(implicit hc: HeaderCarrier, language: Lang): Future[Option[String]] = {
     val addressLookupUrl = s"${appConfig.addressLookupUrl}/api/v2/init"
-    val addressConfig = Json.toJson(addressLookupConfig.config(continueUrl = s"$continueUrl"))
+    val addressConfig = Json.toJson(addressLookupConfig.config(continueUrl = s"$continueUrl", accessibilityFooterUrl))
     http.POST(addressLookupUrl, body = addressConfig).map {
       response =>
         response.status match {

--- a/app/controllers/IsPaymentAddressInTheUKController.scala
+++ b/app/controllers/IsPaymentAddressInTheUKController.scala
@@ -68,9 +68,10 @@ cc: MessagesControllerComponents,
             case NormalMode => appConfig.addressLookupContinueUrlNormalMode
             case CheckMode => appConfig.addressLookupContinueUrlCheckMode
           }
-
+          val accessibilityFooterUrl = routes.AccessibilityController.onPageLoad().absoluteURL
           val addressInit = for {
-            result: Option[String] <- addressLookup.initialise(continueUrl = continueUrl)(hc: HeaderCarrier, language)
+            result: Option[String] <- addressLookup.initialise(continueUrl = continueUrl,
+              accessibilityFooterUrl = accessibilityFooterUrl)(hc: HeaderCarrier, language)
           } yield {
             result map (
               url => Redirect(url)

--- a/build.sbt
+++ b/build.sbt
@@ -18,24 +18,24 @@ lazy val playSettings: Seq[Setting[_]] = Seq.empty
 
 val compile = Seq(
   ws,
-  "uk.gov.hmrc"           %% "bootstrap-play-26"              % "1.3.0",
-  "uk.gov.hmrc"           %% "simple-reactivemongo"           % "7.23.0-play-26",
-  "uk.gov.hmrc"           %% "govuk-template"                 % "5.48.0-play-26",
-  "uk.gov.hmrc"           %% "play-health"                    % "3.14.0-play-26",
-  "uk.gov.hmrc"           %% "play-ui"                        % "8.8.0-play-26",
+  "uk.gov.hmrc"           %% "bootstrap-play-26"              % "1.7.0",
+  "uk.gov.hmrc"           %% "simple-reactivemongo"           % "7.26.0-play-26",
+  "uk.gov.hmrc"           %% "govuk-template"                 % "5.54.0-play-26",
+  "uk.gov.hmrc"           %% "play-health"                    % "3.15.0-play-26",
+  "uk.gov.hmrc"           %% "play-ui"                        % "8.9.0-play-26",
   "uk.gov.hmrc"           %% "http-caching-client"            % "9.0.0-play-26",
   "uk.gov.hmrc"           %% "play-conditional-form-mapping"  % "1.2.0-play-26",
-  "uk.gov.hmrc"           %% "play-partials"                  % "6.9.0-play-26",
+  "uk.gov.hmrc"           %% "play-partials"                  % "6.10.0-play-26",
   "uk.gov.hmrc"           %% "play-language"                  % "4.2.0-play-26",
   "uk.gov.hmrc"           %% "tax-year"                       % "1.0.0",
-  "org.scalatra.scalate"  %% "play-scalate"                   % "0.5.0",
-  "org.scalatra.scalate"  %% "scalate-core"                   % "1.9.1",
-  "uk.gov.hmrc"           %% "domain"                         % "5.6.0-play-26"
+  "org.scalatra.scalate"  %% "play-scalate"                   % "0.6.0",
+  "org.scalatra.scalate"  %% "scalate-core"                   % "1.9.5",
+  "uk.gov.hmrc"           %% "domain"                         % "5.8.0-play-26"
 )
 
 def test(scope: String = "test"): Seq[ModuleID] = Seq(
-  "com.github.tomakehurst"  % "wiremock"                % "2.25.1" % scope,
-  "com.github.tomakehurst"  % "wiremock-jre8"           % "2.25.1" % scope,
+  "com.github.tomakehurst"  % "wiremock"                % "2.26.3" % scope,
+  "com.github.tomakehurst"  % "wiremock-jre8"           % "2.26.3" % scope,
   "uk.gov.hmrc"             %% "hmrctest"               % "3.9.0-play-26" % scope,
   "org.scalatest"           %% "scalatest"              % "3.0.8" % scope,
   "org.scalatestplus.play"  %% "scalatestplus-play"     % "3.1.2" % scope,
@@ -44,7 +44,7 @@ def test(scope: String = "test"): Seq[ModuleID] = Seq(
   "org.jsoup"               % "jsoup"                   % "1.12.1" % scope,
   "com.typesafe.play"       %% "play-test"              % PlayVersion.current % scope,
   "org.mockito"             % "mockito-all"             % "1.10.19" % scope,
-  "uk.gov.hmrc"             %% "play-whitelist-filter"  % "3.1.0-play-26"
+  "uk.gov.hmrc"             %% "play-whitelist-filter"  % "3.3.0-play-26"
 )
 
 def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,13 +10,13 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 libraryDependencies += "io.monix" %% "monix" % "2.3.3" pomOnly()
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 

--- a/test/config/AddressLookupConfigSpec.scala
+++ b/test/config/AddressLookupConfigSpec.scala
@@ -30,7 +30,7 @@ class AddressLookupConfigSpec extends SpecBase {
 
     for (lang <- languages) {
       s" have ${lang.code} labels " must {
-        val addressConfig = addressLookupConfig.config(continueUrl = s"")(lang)
+        val addressConfig = addressLookupConfig.config(continueUrl = s"", accessibilityFooterUrl = "")(lang)
         "have appsLevel labels" must {
           s"""have correct nav Title of "${messagesApi("index.title")(lang)}" """ in {
             val element = addressConfig \ "labels" \ lang.code \ "appLevelLabels" \ "navTitle"

--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -86,7 +86,7 @@ class AddressLookupConnectorSpec extends SpecBase with MockitoSugar with WireMoc
           )
       )
 
-      val result: Option[String] = Await.result(connector.initialise(continueUrl = ""), 500.millisecond)
+      val result: Option[String] = Await.result(connector.initialise(continueUrl = "", accessibilityFooterUrl = ""), 500.millisecond)
       result mustBe Some("/api/v2/location")
 
     }
@@ -102,7 +102,7 @@ class AddressLookupConnectorSpec extends SpecBase with MockitoSugar with WireMoc
           )
       )
 
-      val result: Option[String] = Await.result(connector.initialise(""), 500.millisecond)
+      val result: Option[String] = Await.result(connector.initialise("", ""), 500.millisecond)
       result mustBe Some(s"[AddressLookupConnector][initialise] - Failed to obtain location from http://localhost:${server.port}/api/v2/init")
     }
 
@@ -115,7 +115,7 @@ class AddressLookupConnectorSpec extends SpecBase with MockitoSugar with WireMoc
           )
       )
 
-      val result: Option[String] = Await.result(connector.initialise(""), 500.millisecond)
+      val result: Option[String] = Await.result(connector.initialise("", ""), 500.millisecond)
       result mustBe None
     }
 
@@ -127,7 +127,7 @@ class AddressLookupConnectorSpec extends SpecBase with MockitoSugar with WireMoc
           )
       )
 
-      val result: Future[Option[String]] = connector.initialise("")
+      val result: Future[Option[String]] = connector.initialise("", "")
       whenReady(result) {
         res =>
           res mustBe None
@@ -144,7 +144,7 @@ class AddressLookupConnectorSpec extends SpecBase with MockitoSugar with WireMoc
           )
       )
 
-      val result: Future[Option[String]] = connector.initialise("")
+      val result: Future[Option[String]] = connector.initialise("", "")
       whenReady(result) {
         res =>
           res mustBe None

--- a/test/controllers/IsPaymentAddressInTheUKControllerSpec.scala
+++ b/test/controllers/IsPaymentAddressInTheUKControllerSpec.scala
@@ -56,7 +56,7 @@ class IsPaymentAddressInTheUKControllerSpec extends ControllerSpecBase with Mock
   "IsPaymentAddressInTheUK Controller" must {
 
     "return OK and the correct view for a GET" in {
-      when (mockAddressLookup.initialise(any())(any(), any())) thenReturn Future.successful(None)
+      when (mockAddressLookup.initialise(any(), any())(any(), any())) thenReturn Future.successful(None)
       val result = controller(fakeDataRetrievalAction()).onPageLoad(NormalMode)(fakeRequest)
 
       status(result) mustBe OK
@@ -64,7 +64,7 @@ class IsPaymentAddressInTheUKControllerSpec extends ControllerSpecBase with Mock
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
-      when (mockAddressLookup.initialise(any())(any(), any())).thenReturn(Future.successful(None))
+      when (mockAddressLookup.initialise(any(), any())(any(), any())).thenReturn(Future.successful(None))
       when (mockUserAnswers.isPaymentAddressInTheUK) thenReturn Some(true)
       val result = controller(fakeDataRetrievalAction(mockUserAnswers)).onPageLoad(NormalMode)(fakeRequest)
 
@@ -73,7 +73,7 @@ class IsPaymentAddressInTheUKControllerSpec extends ControllerSpecBase with Mock
 
     "redirect to address lookup address when able to connect to the api" in {
       val url: String = "http://localhost:9028/lookup-address/ca36139b-cee5-4a99-902c-ce7b9963d7ce/lookup"
-      when (mockAddressLookup.initialise(any())(any(), any())).thenReturn(Future.successful(Some(url)))
+      when (mockAddressLookup.initialise(any(), any())(any(), any())).thenReturn(Future.successful(Some(url)))
       val result = controller(fakeDataRetrievalAction()).onPageLoad(NormalMode)(fakeRequest)
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some("http://localhost:9028/lookup-address/ca36139b-cee5-4a99-902c-ce7b9963d7ce/lookup")


### PR DESCRIPTION
# DL-2971 - CTR to pass accessibility statement URL to the address lookup service

Updated `AddressLookupConfig` to pass the reverse route of `/claim-tax-refund/accessibility` in the JSON field [`accessibilityFooterUrl`](https://github.com/hmrc/address-lookup-frontend#top-level-configuration-json-object).

Also raised a PR for [`service-manager-config`](https://github.com/hmrc/service-manager-config/pull/2123) to set the Scala version of the artefact to 2.12, as service manager is still pulling the latest 2.11 version of this service (`0.202.0`).

Raised a PR for [`claim-tax-refund-journey-tests`](https://github.com/hmrc/claim-tax-refund-journey-tests/pull/18) to update the assertions against address lookup's confirmation page titles (which have changed since `address-lookup-frontend-2.65.0`)

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
