### PR TITLE
DL-2971 - changed accessibility url from absolute to relative

### DIFF
--- a/app/controllers/IsPaymentAddressInTheUKController.scala
+++ b/app/controllers/IsPaymentAddressInTheUKController.scala
@@ -68,7 +68,7 @@ cc: MessagesControllerComponents,
             case NormalMode => appConfig.addressLookupContinueUrlNormalMode
             case CheckMode => appConfig.addressLookupContinueUrlCheckMode
           }
-          val accessibilityFooterUrl = routes.AccessibilityController.onPageLoad().absoluteURL
+          val accessibilityFooterUrl = routes.AccessibilityController.onPageLoad().url
           val addressInit = for {
             result: Option[String] <- addressLookup.initialise(continueUrl = continueUrl,
               accessibilityFooterUrl = accessibilityFooterUrl)(hc: HeaderCarrier, language)


### PR DESCRIPTION
# DL-2971 - CTR to pass accessibility statement URL to the address lookup service

Related to PR https://github.com/hmrc/claim-tax-refund-frontend/pull/478, the absolute url to `claim-tax-refund/accessibility` didn't resolve successfully in qa/staging.
This PR makes the URL relative (which will not resolve against localhost/will not work locally).

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
