### PR TITLE
DL-5929 hmrcTimeoutDialogHelper added

### DIFF
--- a/app/controllers/SessionExpiredController.scala
+++ b/app/controllers/SessionExpiredController.scala
@@ -31,12 +31,10 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class SessionExpiredController @Inject()(val appConfig: FrontendAppConfig,
                                          sessionExpired: session_expired,
-                                         cc: MessagesControllerComponents,
-                                         implicit val templateRenderer: LocalTemplateRenderer,
-                                         implicit val ec: ExecutionContext
+                                         cc: MessagesControllerComponents
                                         ) extends FrontendController(cc) with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = Action { implicit request =>
-    Ok(sessionExpired(appConfig))
+    Ok(sessionExpired(appConfig)).withNewSession
   }
 }

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -30,29 +30,47 @@
         appConfig: FrontendAppConfig
 )
 
-@(pageTitle: String)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+@(
+        pageTitle: String,
+        timeoutEnabled: Boolean = true,
+        backLinkEnabled: Boolean = true,
+        accountMenuEnabled: Boolean = true)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @accountMenu = {
-    @hmrcAccountMenu(AccountMenu(
-        accountHome = AccountHome(
-            href = appConfig.ptaHomeUrl,
-            active = true
-        ),
-        messages = AccountMessages(
-            href = appConfig.messagesUrl,
-            messageCount = None
-        ),
-        checkProgress = CheckProgress(
-            href = appConfig.trackingHomeUrl
-        ),
-        paperlessSettings = PaperlessSettings(appConfig.paperlessSettingsUrl),
-        personalDetails = PersonalDetails(appConfig.personalDetailsUrl),
-        signOut = SignOut(appConfig.signOutUrl),
-        language = if (messages.lang.code == "cy") Cy else En
-    ))
+    @if(accountMenuEnabled) {
+        @hmrcAccountMenu(AccountMenu(
+            accountHome = AccountHome(
+                href = appConfig.ptaHomeUrl,
+                active = true
+            ),
+            messages = AccountMessages(
+                href = appConfig.messagesUrl,
+                messageCount = None
+            ),
+            checkProgress = CheckProgress(
+                href = appConfig.trackingHomeUrl
+            ),
+            paperlessSettings = PaperlessSettings(appConfig.paperlessSettingsUrl),
+            personalDetails = PersonalDetails(appConfig.personalDetailsUrl),
+            signOut = SignOut(appConfig.signOutUrl),
+            language = if(messages.lang.code == "cy") Cy else En
+        ))
+    }
 
     @hmrcLanguageSelectHelper()
-    @backLink()
+
+    @if(backLinkEnabled) { @backLink() }
+}
+
+@head = {
+    @if(timeoutEnabled) {
+        @hmrcTimeoutDialogHelper(
+            signOutUrl = controllers.routes.SessionExpiredController.onPageLoad().url,
+            message = Some(Messages("timeout.message")),
+            keepAliveButtonText = Some(Messages("timeout.continue")),
+            signOutButtonText = Some(Messages("timeout.exit"))
+        )
+    }
 }
 
 
@@ -63,7 +81,9 @@
 
 @govukLayout(
     pageTitle = Some(pageTitle),
-    headBlock = Some(hmrcHead()),
+    headBlock = Some(hmrcHead(
+        headBlock = Some(head)
+    )),
     headerBlock = Some(hmrcStandardHeader(
         serviceUrl = Some(controllers.routes.IndexController.onPageLoad().url)
     )),

--- a/app/views/session_expired.scala.html
+++ b/app/views/session_expired.scala.html
@@ -15,27 +15,33 @@
  *@
 
 @import config.FrontendAppConfig
-@import uk.gov.hmrc.renderer.TemplateRenderer
-@import scala.concurrent.ExecutionContext
 
-@this(main_template: main_template)
+
+@this(
+        layout: Layout,
+        govukButton : GovukButton
+)
 
 @(
         appConfig: FrontendAppConfig
 )(
         implicit
         request: Request[_],
-        messages: Messages,
-templateRenderer: TemplateRenderer,
-ec: ExecutionContext)
+        messages: Messages
+)
 
-@main_template(
-    title = messages("session_expired.title"),
-    appConfig = appConfig,
-    bodyClasses = None,
-    timeout = false
+@layout(
+    pageTitle=messages("session_expired.title"),
+    timeoutEnabled = false,
+    backLinkEnabled = false,
+    accountMenuEnabled = false
 ) {
-    <h1 class="heading-xlarge">@messages("session_expired.heading")</h1>
+    <h1 class="govuk-heading-xl">@messages("session_expired.heading")</h1>
 
-    <a href=/claim-tax-refund class="button" role="button">@messages("session_expired.button")</a>
+    <div class="govuk-button-group">
+        @govukButton(Button(
+            href = Some(controllers.routes.IndexController.onPageLoad().url),
+            content = Text(messages("session_expired.button"))
+        ))
+    </div>
 }

--- a/test/controllers/SessionExpiredControllerSpec.scala
+++ b/test/controllers/SessionExpiredControllerSpec.scala
@@ -26,13 +26,13 @@ class SessionExpiredControllerSpec extends ControllerSpecBase with GuiceOneAppPe
 
   "SessionExpired Controller" must {
     "return 200 for a GET" in {
-      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents, templateRenderer, ec).onPageLoad()(fakeRequest)
+      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents).onPageLoad()(fakeRequest)
       status(result) mustBe OK
     }
 
     "return the correct view for a GET" in {
-      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents, templateRenderer, ec).onPageLoad()(fakeRequest)
-      contentAsString(result) mustBe sessionExpired(frontendAppConfig)(fakeRequest, messages, templateRenderer, ec).toString
+      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents).onPageLoad()(fakeRequest)
+      contentAsString(result) mustBe sessionExpired(frontendAppConfig)(fakeRequest, messages).toString
     }
   }
 }

--- a/test/views/SessionExpiredViewSpec.scala
+++ b/test/views/SessionExpiredViewSpec.scala
@@ -24,7 +24,7 @@ class SessionExpiredViewSpec extends ViewBehaviours with GuiceOneAppPerSuite {
 
   val sessionExpired: session_expired = fakeApplication.injector.instanceOf[session_expired]
 
-  def view = () => sessionExpired(frontendAppConfig)(fakeRequest, messages, templateRenderer, ec)
+  def view = () => sessionExpired(frontendAppConfig)(fakeRequest, messages)
 
   "Session Expired view" must {
 


### PR DESCRIPTION
# DL-5929 hmrcTimeoutDialogHelper added

**New feature**

- Updated SessionExpiredController to discard the existing session
- Added hmrcTimeoutDialogHelper to Layout.scala.html (https://github.com/hmrc/play-frontend-hmrc#how-to-integrate-with-the-timeout-dialog)
- Updated the session_expired.scala.html view to be DI, not show the account menu, not show the back link and to not trigger the timeout dialog
- 
## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
