### PR TITLE
DL-5917 - taxable-benefits

### DIFF
--- a/app/controllers/AnyBenefitsController.scala
+++ b/app/controllers/AnyBenefitsController.scala
@@ -61,7 +61,7 @@ cc: MessagesControllerComponents,
       request.userAnswers.selectTaxYear.map {
         selectedTaxYear =>
           val taxYear = selectedTaxYear
-          Ok(anyBenefits(appConfig, preparedForm, mode, taxYear))
+          Ok(anyBenefits(preparedForm, mode, taxYear))
       }.getOrElse {
         Redirect(routes.SessionExpiredController.onPageLoad())
       }
@@ -76,7 +76,7 @@ cc: MessagesControllerComponents,
           val taxYear = selectedTaxYear
           form.bindFromRequest().fold(
             (formWithErrors: Form[_]) =>
-              Future.successful(BadRequest(anyBenefits(appConfig, formWithErrors, mode, taxYear))),
+              Future.successful(BadRequest(anyBenefits(formWithErrors, mode, taxYear))),
             value =>
               dataCacheConnector.save[Boolean](request.externalId, AnyBenefitsId.toString, value).map(cacheMap =>
                 Redirect(navigator.nextPage(AnyBenefitsId, mode)(new UserAnswers(cacheMap))))

--- a/app/views/anyBenefits.scala.html
+++ b/app/views/anyBenefits.scala.html
@@ -22,10 +22,18 @@
 @import uk.gov.hmrc.renderer.TemplateRenderer
 @import scala.concurrent.ExecutionContext
 
-@this(main_template: main_template, formWithCSRF: FormWithCSRF)
+@this(
+    layout: Layout,
+    pageHeading: hmrcPageHeading,
+    radioButtons: govukRadios,
+    submitButton: playComponents.submit_button,
+    errorSummary: playComponents.error_summary,
+    formWithCSRF: FormWithCSRF,
+    inputRadio: playComponents.input_radio,
+    inputYesNo: playComponents.input_yes_no
+)
 
 @(
-        appConfig: FrontendAppConfig,
         form: Form[_],
         mode: Mode,
         taxYear: SelectTaxYear
@@ -33,41 +41,37 @@
         implicit
         request: Request[_],
         messages: Messages,
-templateRenderer: TemplateRenderer,
 ec: ExecutionContext)
 
-    @title = @{
-        if(form.errors.nonEmpty) messages("site.title.error", messages("anyBenefits.title")) else messages("anyBenefits.title")
+@title = @{
+    if(form.errors.nonEmpty) messages("site.title.error", messages("anyBenefits.heading")) else messages("anyBenefits.heading")
+}
+
+@layout(
+    pageTitle = title
+) {
+    @formWithCSRF(action = AnyBenefitsController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @errorSummary(form.errors)
+
+        @pageHeading(PageHeading(
+            text = messages("anyBenefits.heading"),
+            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
+        ))
+
+        <p class="govuk-body" id="listHeading">@messages("anyBenefits.listHeading")</p>
+
+        @playComponents.list(pageKey = Some("selectBenefits"),
+                         bulletList = Benefits.sortedBenefits.dropRight(1).map(_.toString))
+
+        @inputYesNo(
+            viewModel = InputViewModel("value", form),
+            label = messages("anyBenefits.heading"),
+            labelClass = Some("govuk-visually-hidden"),
+            field = form("value")
+        )
+
+        @submitButton()
     }
+}
 
-    @main_template(
-        title = title,
-        appConfig = appConfig,
-        bodyClasses = None
-    ) {
-
-        @formWithCSRF(action = AnyBenefitsController.onSubmit(mode), 'autoComplete -> "off") {
-
-            @components.back_link()
-
-            @components.error_summary(form.errors)
-
-            @components.heading(messages("anyBenefits.heading"), taxYear = Some(taxYear.asString))
-
-            <p id="listHeading">@messages("anyBenefits.listHeading")</p>
-
-            @components.list(
-                pageKey = Some("selectBenefits"),
-                addCssClass = None,
-                bulletList = Benefits.sortedBenefits.dropRight(1).map(_.toString)
-            )
-
-            @components.input_yes_no(
-                InputViewModel("value", form),
-                label = messages("anyBenefits.heading", taxYear.asString),
-                labelClass = Some("visually-hidden")
-            )
-
-            @components.submit_button()
-        }
-    }

--- a/app/views/playComponents/input_yes_no.scala.html
+++ b/app/views/playComponents/input_yes_no.scala.html
@@ -15,39 +15,28 @@
  *@
 
 @import viewmodels.InputViewModelBase
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
+@this(govukRadios : GovukRadios)
 
 @(
-viewModel: InputViewModelBase,
-label: String,
-secondaryLabel: Option[String] = None,
-inputClass: Option[String] = None,
-hint: Option[String] = None,
-yesAssoc: Option[String] = None,
-noAssoc: Option[String] = None,
-labelClass: Option[String] = None
+    viewModel: InputViewModelBase,
+    label: String,
+    hint: Option[String] = None,
+    labelClass: Option[String] = None,
+    field: Field
 )(implicit messages: Messages)
-
-
-<div class="form-group @if(viewModel.errorKey.nonEmpty){form-field--error}">
-    <fieldset class="inline" id="@{viewModel.id}">
-
-        <legend>
-          <span @if(labelClass.nonEmpty){class="@labelClass"}>@label</span>
-          @if(hint.nonEmpty){
-            <span class="form-hint">@hint</span>
-          }
-          @if(viewModel.errorKey.nonEmpty){
-            <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>
-          }
-        </legend>
-        <div class="multiple-choice" data-target="@if(yesAssoc.nonEmpty){@yesAssoc}">
-            <input id="@{viewModel.id}-yes" type="radio" name="@{viewModel.id}" value="true" @if(viewModel.value.contains("true")){checked="checked"} />
-            <label for="@{viewModel.id}-yes" > @messages("site.yes") </label>
-        </div>
-        <div class="multiple-choice" data-target="@if(noAssoc.nonEmpty){@noAssoc}">
-            <input id="@{viewModel.id}-no" type="radio" name="@{viewModel.id}" value="false" @if(viewModel.value.contains("false")){checked="checked"} />
-            <label for="@{viewModel.id}-no" > @messages("site.no") </label>
-        </div>
-
-    </fieldset>
-</div>
+    @govukRadios(Radios(
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(content = Text(label),
+                classes = s"""govuk-fieldset__legend--l ${labelClass.getOrElse("")}""",
+                isPageHeading = true
+            ))
+        )),
+        hint = hint.map(hintString => Hint(content = Text(hintString))),
+        items = Seq("yes", "no").map(answer =>
+            RadioItem(value = Some((answer == "yes").toString),
+                      content = Text(messages(s"site.$answer"))
+        )),
+        classes = "govuk-radios--inline"
+    ).withFormField(field))

--- a/app/views/playComponents/list.scala.html
+++ b/app/views/playComponents/list.scala.html
@@ -29,7 +29,7 @@
 }
 
 @list = {
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
         @for(bullet <- bulletList) {
             <li id="bullet-@bullet">@text(bullet)</li>
         }

--- a/test/controllers/AnyBenefitsControllerSpec.scala
+++ b/test/controllers/AnyBenefitsControllerSpec.scala
@@ -47,7 +47,7 @@ class AnyBenefitsControllerSpec extends ControllerSpecBase with MockitoSugar wit
     new AnyBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, mockTai, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), anyBenefits, messagesControllerComponents, formProvider, templateRenderer)
 
-  def viewAsString(form: Form[_] = form) = anyBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec).toString
+  def viewAsString(form: Form[_] = form) = anyBenefits(form, NormalMode, taxYear)(fakeRequest, messages, ec).toString
 
   "AnyBenefits Controller" must {
 

--- a/test/views/AnyBenefitsViewSpec.scala
+++ b/test/views/AnyBenefitsViewSpec.scala
@@ -23,10 +23,10 @@ import models.SelectTaxYear.CustomTaxYear
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
-import views.behaviours.YesNoViewBehaviours
+import views.behaviours.{NewYesNoViewBehaviours, YesNoViewBehaviours}
 import views.html.anyBenefits
 
-class AnyBenefitsViewSpec extends YesNoViewBehaviours with GuiceOneAppPerSuite {
+class AnyBenefitsViewSpec extends NewYesNoViewBehaviours with GuiceOneAppPerSuite {
 
   private val messageKeyPrefix = "anyBenefits"
   private val listMessageKeyPrefix = "selectBenefits"
@@ -36,11 +36,11 @@ class AnyBenefitsViewSpec extends YesNoViewBehaviours with GuiceOneAppPerSuite {
   override val form = new BooleanForm()()
 
   def createView: () => HtmlFormat.Appendable = () =>
-    anyBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+    anyBenefits(form, NormalMode, taxYear)(fakeRequest, messages, ec)
 
   def createViewUsingForm: Form[_] =>
 		HtmlFormat.Appendable = (form: Form[_]) =>
-			anyBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+			anyBenefits(form, NormalMode, taxYear)(fakeRequest, messages, ec)
 
   "AnyBenefits view" must {
 

--- a/test/views/NewViewSpecBase.scala
+++ b/test/views/NewViewSpecBase.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.SpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.Html
+
+trait NewViewSpecBase extends SpecBase {
+
+  def asDocument(html: Html): Document = Jsoup.parse(html.toString())
+
+  def assertEqualsMessage(doc: Document, cssSelector: String, expectedMessageKey: String, args: Any*) =
+    assertEqualsValue(doc, cssSelector, messages(expectedMessageKey, args: _*))
+
+  def assertEqualsValue(doc: Document, cssSelector: String, expectedValue: String) = {
+    val elements = doc.select(cssSelector)
+
+    if (elements.isEmpty) throw new IllegalArgumentException(s"CSS Selector $cssSelector wasn't rendered.")
+
+    //<p> HTML elements are rendered out with a carriage return on some pages, so discount for comparison
+    assert(elements.first().html().replace("\n", "") == expectedValue)
+  }
+
+  def assertPageTitleEqualsMessage(doc: Document, expectedMessageKey: String, args: Any*) = {
+    val headers = doc.getElementsByTag("h1")
+    headers.first.text.replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args: _*).replaceAll("&nbsp;", " ")
+  }
+
+  def assertContainsText(doc: Document, text: String) = assert(doc.toString.contains(text), "\n\ntext " + text + " was not rendered on the page.\n")
+
+  def assertContainsMessages(doc: Document, expectedMessageKeys: String*) = {
+    for (key <- expectedMessageKeys) assertContainsText(doc, messages(key))
+  }
+
+  def assertRenderedById(doc: Document, id: String) = {
+    assert(doc.getElementById(id) != null, "\n\nElement " + id + " was not rendered on the page.\n")
+  }
+
+  def assertNotRenderedById(doc: Document, id: String) = {
+    assert(doc.getElementById(id) == null, "\n\nElement " + id + " was rendered on the page.\n")
+  }
+
+  def assertRenderedByCssSelector(doc: Document, cssSelector: String) = {
+    assert(!doc.select(cssSelector).isEmpty, "Element " + cssSelector + " was not rendered on the page.")
+  }
+
+  def assertNotRenderedByCssSelector(doc: Document, cssSelector: String) = {
+    assert(doc.select(cssSelector).isEmpty, "\n\nElement " + cssSelector + " was rendered on the page.\n")
+  }
+
+  def assertContainsLabel(doc: Document, forElement: String, expectedText: String, expectedHintTextLine1: Option[String] = None,
+                          expectedHintTextLine2: Option[String] = None) = {
+    val labels = doc.getElementsByAttributeValue("for", forElement)
+    assert(labels.size == 1, s"\n\nLabel for $forElement was not rendered on the page.")
+    val label = labels.first
+    assert(label.child(0).text == expectedText, s"\n\nLabel for $forElement was not $expectedText")
+
+    if (expectedHintTextLine1.isDefined) {
+      assert(label.getElementsByClass("form-hint").first.text == expectedHintTextLine1.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine1")
+    }
+
+    if (expectedHintTextLine2.isDefined) {
+      assert(label.getElementById("hint-line-2").text == expectedHintTextLine2.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine2")
+    }
+  }
+
+  def assertElementHasClass(doc: Document, id: String, expectedClass: String) = {
+    assert(doc.getElementById(id).hasClass(expectedClass), s"\n\nElement $id does not have class $expectedClass")
+  }
+
+  def assertContainsRadioButton(doc: Document, id: String, name: String, value: String, isChecked: Boolean) = {
+    assertRenderedById(doc, id)
+    val radio = doc.getElementById(id)
+    assert(radio.attr("name") == name, s"\n\nElement $id does not have name $name")
+    assert(radio.attr("value") == value, s"\n\nElement $id does not have value $value")
+    isChecked match {
+      case true => assert(radio.attr("checked") != null, s"\n\nElement $id is not checked")
+      case _ => assert(!radio.hasAttr("checked") && radio.attr("checked") != "checked", s"\n\nElement $id is checked")
+    }
+  }
+
+  def assertYesNoHint(doc: Document, expectedText: Option[String]) = {
+    val hint = doc.getElementsByClass("form-hint")
+    assert(hint != null , "\n\nhint was rendered on the page.\n")
+    assert(hint.text.contains(messages(expectedText.get)))
+  }
+
+}

--- a/test/views/behaviours/NewQuestionViewBehaviours.scala
+++ b/test/views/behaviours/NewQuestionViewBehaviours.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import play.api.data.{Form, FormError}
+import play.twirl.api.HtmlFormat
+
+trait NewQuestionViewBehaviours[A] extends NewViewBehaviours {
+
+  val errorKey = "value"
+  val errorMessage = "error.number"
+  val error = FormError(errorKey, errorMessage)
+
+  val form: Form[A]
+
+  def pageWithTextFields(createView: Form[A] => HtmlFormat.Appendable,
+                         messageKeyPrefix: String,
+                         expectedFormAction: String,
+                         fields: String*) = {
+
+    "behave like a question page" when {
+      "rendered" must {
+        for (field <- fields) {
+          s"contain an input for $field" in {
+            val doc = asDocument(createView(form))
+            assertRenderedById(doc, field)
+          }
+        }
+
+        "not render an error summary" in {
+          val doc = asDocument(createView(form))
+          assertNotRenderedById(doc, "error-summary-heading")
+        }
+
+
+        "show error in the title" in {
+          val doc = asDocument(createView(form.withError(error)))
+          doc.title.contains("Error: ") mustBe true
+        }
+      }
+
+      for (field <- fields) {
+        s"rendered with an error with field '$field'" must {
+          "show an error summary" in {
+            val doc = asDocument(createView(form.withError(FormError(field, "error"))))
+            assertRenderedById(doc, "error-summary-heading")
+          }
+
+          s"show an error in the label for field '$field'" in {
+            val doc = asDocument(createView(form.withError(FormError(field, "error"))))
+            val errorSpan = doc.getElementsByClass("error-notification").first
+            errorSpan.parent.attr("for") mustBe field
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/views/behaviours/NewViewBehaviours.scala
+++ b/test/views/behaviours/NewViewBehaviours.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import org.jsoup.Jsoup
+import play.twirl.api.HtmlFormat
+import views.{NewViewSpecBase, ViewSpecBase}
+
+trait NewViewBehaviours extends NewViewSpecBase {
+
+  def normalPage(view: () => HtmlFormat.Appendable,
+                 messageKeyPrefix: String,
+                 expectedGuidanceKeys: Option[String],
+                 args: Any*) = {
+
+    "behave like a normal page" when {
+      "rendered" must {
+        "display the correct browser title" in {
+          val doc = asDocument(view())
+          assertEqualsMessage(doc, "title", s"$messageKeyPrefix.title", args: _*)
+        }
+
+        "display the correct page title" in {
+          val doc = asDocument(view())
+          assertPageTitleEqualsMessage(doc, s"$messageKeyPrefix.heading", args: _*)
+        }
+
+        "display the correct guidance" in {
+          val doc = asDocument(view())
+          for (key <- expectedGuidanceKeys) assertContainsText(doc, messages(s"$messageKeyPrefix.$key"))
+        }
+      }
+    }
+  }
+
+  def pageWithBackLink(view: () => HtmlFormat.Appendable) = {
+
+    "behave like a page with a back link" must {
+      "have a back link" in {
+        val doc = asDocument(view())
+        assertRenderedById(doc, "back-link")
+      }
+    }
+  }
+
+  def pageWithSecondaryHeader(view: () => HtmlFormat.Appendable,
+                              heading: String) = {
+
+    "behave like a page with a secondary header" in {
+      Jsoup.parse(view().toString()).getElementsByClass("hmrc-caption-xl").text() must include(heading)
+    }
+  }
+
+  def pageWithList(view: () => HtmlFormat.Appendable,
+                   pageKey: String,
+                   bulletList: Seq[String],
+                   messageKeyPrefix: String) = {
+
+    "behave like a page with a list" must {
+      "have a list" in {
+        val doc = asDocument(view())
+        bulletList.foreach {
+          x => assertRenderedById(doc, s"bullet-$x")
+        }
+      }
+
+      "have correct values" in {
+        val doc = asDocument(view())
+        bulletList.foreach{
+          x => assertContainsMessages(doc, s"$messageKeyPrefix.$x")
+        }
+      }
+    }
+  }
+}

--- a/test/views/behaviours/NewYesNoViewBehaviours.scala
+++ b/test/views/behaviours/NewYesNoViewBehaviours.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import forms.BooleanForm
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+
+trait NewYesNoViewBehaviours extends NewQuestionViewBehaviours[Boolean] {
+
+  val formProvider = new BooleanForm()
+  val form = formProvider()
+
+  def yesNoPage(createView: (Form[Boolean]) => HtmlFormat.Appendable,
+                messageKeyPrefix: String,
+                expectedFormAction: String,
+                expectedHintTextKey: Option[String],
+                args: Any*) = {
+
+    "behave like a page with a Yes/No question" when {
+      "rendered" must {
+        "contain a legend for the question" in {
+          val doc = asDocument(createView(form))
+          val legends = doc.getElementsByTag("legend")
+          legends.size mustBe 1
+        }
+
+        "contain a heading" in {
+          val doc = asDocument(createView(form))
+          assertContainsText(doc, messages(s"$messageKeyPrefix.heading", args: _*))
+        }
+
+        if(expectedHintTextKey.isDefined){
+          "render a hint" in {
+            val doc = asDocument(createView(form))
+            assertYesNoHint(doc, expectedHintTextKey)
+          }
+        } else {
+          "not render a hint" in {
+            val doc = asDocument(createView(form))
+            assertNotRenderedByCssSelector(doc, ".form-hint")
+          }
+        }
+
+        "contain an input for the value" in {
+          val doc = asDocument(createView(form))
+          assertRenderedById(doc, "value")
+          assertRenderedById(doc, "value-2")
+        }
+
+        "have no values checked when rendered with no form" in {
+          val doc = asDocument(createView(form))
+          assert(!doc.getElementById("value").hasAttr("checked"))
+          assert(!doc.getElementById("value-2").hasAttr("checked"))
+        }
+
+        "not render an error summary" in {
+          val doc = asDocument(createView(form))
+          assertNotRenderedById(doc, "error-summary_header")
+        }
+
+				"show error in the title" in {
+					val doc = asDocument(createView(form.withError(error)))
+					doc.title.contains("Error: ") mustBe true
+				}
+      }
+
+      "rendered with a value of true" must {
+        behave like answeredYesNoPage(createView, true)
+      }
+
+      "rendered with a value of false" must {
+        behave like answeredYesNoPage(createView, false)
+      }
+
+      "rendered with an error" must {
+        "show an error summary" in {
+          val doc = asDocument(createView(form.withError(error)))
+          assertRenderedById(doc, "error-summary-title")
+        }
+
+        "show an error in the value field's label" in {
+          val doc = asDocument(createView(form.withError(error)))
+          val errorSpan = doc.getElementsByClass("govuk-error-message").first
+          errorSpan.text must include(messages(errorMessage))
+        }
+      }
+    }
+  }
+
+
+  def answeredYesNoPage(createView: (Form[Boolean]) => HtmlFormat.Appendable, answer: Boolean) = {
+
+    "have only the correct value checked" in {
+      val doc = asDocument(createView(form.fill(answer)))
+      assert(doc.getElementById("value").hasAttr("checked") == answer)
+      assert(doc.getElementById("value-2").hasAttr("checked") != answer)
+    }
+
+    "not render an error summary" in {
+      val doc = asDocument(createView(form.fill(answer)))
+      assertNotRenderedById(doc, "error-summary_header")
+    }
+  }
+}


### PR DESCRIPTION
# DL-5917 - taxable-benefits

Changed `anyBenefits.scala.html` displayed on `/claim-tax-refund/taxable-benefits` to use the new playComponents.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
