### PR TITLE
DL-5823 Support legend with caption for input_radio.scala.html

### DIFF
--- a/app/views/playComponents/heading.scala.html
+++ b/app/views/playComponents/heading.scala.html
@@ -27,4 +27,5 @@
 }
 
 <span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
+<h1 class="govuk-fieldset__heading">@heading</h1>
 

--- a/app/views/playComponents/input_radio.scala.html
+++ b/app/views/playComponents/input_radio.scala.html
@@ -20,20 +20,21 @@
 
 @(
     viewModel: InputViewModelBase,
-    legend: String,
+    legend: Html,
     legendClass: Option[String] = None,
     hint: Option[String] = None,
     trackGa: Boolean = false,
     inputs: Seq[RadioItem],
     field: Field)(implicit messages: Messages)
 
+
 @govukRadios(
     Radios(
         fieldset = Some(Fieldset(
             legend = Some(Legend(
-                content = Text(legend),
                 classes = "govuk-fieldset__legend--xl",
-                isPageHeading = true
+                content = HtmlContent(legend),
+                isPageHeading = false
             ))
         )),
         items = inputs

--- a/app/views/selectTaxYear.scala.html
+++ b/app/views/selectTaxYear.scala.html
@@ -18,8 +18,6 @@
 @import controllers.routes._
 @import models.Mode
 @import viewmodels.InputViewModel
-@import uk.gov.hmrc.renderer.TemplateRenderer
-@import scala.concurrent.ExecutionContext
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 
 @this(
@@ -51,12 +49,10 @@
 
         @errorSummary(form.errors)
 
-        @heading(messages("selectTaxYear.heading"))
-
         @inputRadio(
             viewModel = InputViewModel("value", form),
-            legend = messages("selectTaxYear.heading"),
-            legendClass = Some("visually-hidden"),
+            legend = heading(messages("selectTaxYear.heading")),
+            legendClass = None,
             inputs = SelectTaxYear.options map { radioOption =>
                 RadioItem(
                     id = Some(radioOption.id),
@@ -71,28 +67,3 @@
     }
 }
 
-@*
-@main_template(
-    title = title,
-    appConfig = appConfig,
-    bodyClasses = None
-) {
-    @formWithCSRF(action = SelectTaxYearController.onSubmit(mode), 'autoComplete -> "off") {
-
-        @components.back_link()
-
-        @components.error_summary(form.errors)
-
-        @components.heading(messages("selectTaxYear.heading"))
-
-        @components.input_radio(
-            viewModel = InputViewModel("value", form),
-            legend = messages("selectTaxYear.heading"),
-            legendClass = Some("visually-hidden"),
-            inputs = SelectTaxYear.options
-        )
-
-        @components.submit_button()
-    }
-}
-*@


### PR DESCRIPTION
# DL-5823 Support legend with caption for input_radio.scala.html

**New feature**

> If you are asking just one question per page as recommended, you can set the contents of the <legend> as the page heading - https://design-system.service.gov.uk/

Rework to the `input_radio.scala.html` CTR component to display a `caption` with the H1 that the `govukRadio` component does not support directly.

https://github.com/hmrc/play-frontend-govuk/blob/master/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/govukFieldset.scala.html#L26

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
