### PR TITLE
DL-5823 Support legend with caption for input_radio.scala.html

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -33,7 +33,7 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   private def loadConfigInt(key: String): Int = Try(servicesConfig.getInt(key)).getOrElse(throw new Exception(s"Missing configuration key: $key"))
 
   private lazy val contactHost = configuration.getOptional[String]("contact-frontend.host").getOrElse("")
-  private val contactFormServiceIdentifier = "claimtaxrefundfrontend"
+  lazy val contactFormServiceIdentifier = loadConfig("contact-frontend.serviceId")
 
   lazy val assetsPrefix: String = loadConfig(s"assets.url") + loadConfig(s"assets.version") + '/'
   lazy val frontendTemplatePath: String = loadConfig("microservice.services.frontend-template-provider.path")
@@ -57,6 +57,16 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   lazy val unauthorisedCallback: String = loadConfig("identity-verification-uplift.unauthorised-callback.url")
 
   lazy val taiUrl: String = servicesConfig.baseUrl("tai")
+
+  lazy val ptaBaseUrl = servicesConfig.baseUrl("pertax-frontend")
+  lazy val ptaHomeUrl = s"$ptaBaseUrl${servicesConfig.getConfString("pertax-frontend.urls.home","/personal-account")}"
+  lazy val messagesUrl = s"$ptaBaseUrl${servicesConfig.getConfString("pertax-frontend.urls.messages","/messages")}"
+  lazy val paperlessSettingsUrl = s"$ptaBaseUrl${servicesConfig.getConfString("pertax-frontend.urls.paperlessSettings","/preferences")}"
+  lazy val personalDetailsUrl = s"$ptaBaseUrl${servicesConfig.getConfString("pertax-frontend.urls.personalDetails","/personal-details")}"
+  lazy val signOutUrl = s"$ptaBaseUrl${servicesConfig.getConfString("pertax-frontend.urls.signOut","/signout?continueUrl=%2Ffeedback%2FCTR")}"
+
+  lazy val trackingBaseUrl = servicesConfig.baseUrl("tracking-frontend")
+  lazy val trackingHomeUrl = s"$trackingBaseUrl${servicesConfig.getConfString("tracking-frontend.urls.home","/track")}"
 
   lazy val languageTranslationEnabled: Boolean = Try(servicesConfig.getBoolean("microservice.services.features.welsh-translation")).getOrElse(true)
 

--- a/app/controllers/AnyBenefitsController.scala
+++ b/app/controllers/AnyBenefitsController.scala
@@ -61,7 +61,7 @@ cc: MessagesControllerComponents,
       request.userAnswers.selectTaxYear.map {
         selectedTaxYear =>
           val taxYear = selectedTaxYear
-          Ok(anyBenefits(appConfig, preparedForm, mode, taxYear))
+          Ok(anyBenefits(preparedForm, mode, taxYear))
       }.getOrElse {
         Redirect(routes.SessionExpiredController.onPageLoad())
       }
@@ -76,7 +76,7 @@ cc: MessagesControllerComponents,
           val taxYear = selectedTaxYear
           form.bindFromRequest().fold(
             (formWithErrors: Form[_]) =>
-              Future.successful(BadRequest(anyBenefits(appConfig, formWithErrors, mode, taxYear))),
+              Future.successful(BadRequest(anyBenefits(formWithErrors, mode, taxYear))),
             value =>
               dataCacheConnector.save[Boolean](request.externalId, AnyBenefitsId.toString, value).map(cacheMap =>
                 Redirect(navigator.nextPage(AnyBenefitsId, mode)(new UserAnswers(cacheMap))))

--- a/app/controllers/SessionExpiredController.scala
+++ b/app/controllers/SessionExpiredController.scala
@@ -31,12 +31,10 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class SessionExpiredController @Inject()(val appConfig: FrontendAppConfig,
                                          sessionExpired: session_expired,
-                                         cc: MessagesControllerComponents,
-                                         implicit val templateRenderer: LocalTemplateRenderer,
-                                         implicit val ec: ExecutionContext
+                                         cc: MessagesControllerComponents
                                         ) extends FrontendController(cc) with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = Action { implicit request =>
-    Ok(sessionExpired(appConfig))
+    Ok(sessionExpired(appConfig)).withNewSession
   }
 }

--- a/app/forms/SelectBenefitsForm.scala
+++ b/app/forms/SelectBenefitsForm.scala
@@ -21,6 +21,7 @@ import play.api.data.Forms._
 import play.api.data.format.Formatter
 import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.data.{Form, FormError}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.errorsummary.ErrorLink
 
 object SelectBenefitsForm extends FormErrorHelper {
 
@@ -33,6 +34,8 @@ object SelectBenefitsForm extends FormErrorHelper {
 
     def unbind(key: String, value: Benefits.Value) = Map(key -> value.toString)
   }
+
+  ErrorLink
 
   private def optionIsValid(value: String): Boolean = Benefits.sortedBenefits.map(_.toString).contains(value)
 

--- a/app/models/Benefits.scala
+++ b/app/models/Benefits.scala
@@ -25,8 +25,8 @@ object Benefits extends Enumeration {
   val BEREAVEMENT_ALLOWANCE = Value("bereavement-allowance")
   val CARERS_ALLOWANCE = Value("carers-allowance")
   val JOBSEEKERS_ALLOWANCE = Value("jobseekers-allowance")
-  val INCAPACITY_BENEFIT = Value("incapacity-benefit")
   val EMPLOYMENT_AND_SUPPORT_ALLOWANCE = Value("employment-and-support-allowance")
+  val INCAPACITY_BENEFIT = Value("incapacity-benefit")
   val STATE_PENSION = Value("state-pension")
   val OTHER_TAXABLE_BENEFIT = Value("other-taxable-benefit")
 

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -1,0 +1,73 @@
+@*
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+
+@import config.FrontendAppConfig
+
+@this(
+        govukLayout: GovukLayout,
+        hmrcAccountMenu: HmrcAccountMenu,
+        hmrcHead: HmrcHead,
+        hmrcStandardHeader: HmrcStandardHeader,
+        hmrcStandardFooter: HmrcStandardFooter,
+        hmrcScripts: HmrcScripts,
+        hmrcLanguageSelectHelper: HmrcLanguageSelectHelper,
+        hmrcReportTechnicalIssueHelper: HmrcReportTechnicalIssueHelper,
+        hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper,
+        backLink: playComponents.back_link,
+        appConfig: FrontendAppConfig
+)
+
+@(pageTitle: String)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+
+@accountMenu = {
+    @hmrcAccountMenu(AccountMenu(
+        accountHome = AccountHome(
+            href = appConfig.ptaHomeUrl,
+            active = true
+        ),
+        messages = AccountMessages(
+            href = appConfig.messagesUrl,
+            messageCount = None
+        ),
+        checkProgress = CheckProgress(
+            href = appConfig.trackingHomeUrl
+        ),
+        paperlessSettings = PaperlessSettings(appConfig.paperlessSettingsUrl),
+        personalDetails = PersonalDetails(appConfig.personalDetailsUrl),
+        signOut = SignOut(appConfig.signOutUrl),
+        language = if (messages.lang.code == "cy") Cy else En
+    ))
+
+    @hmrcLanguageSelectHelper()
+    @backLink()
+}
+
+
+@mainContent = {
+    @contentBlock
+    @hmrcReportTechnicalIssueHelper()
+}
+
+@govukLayout(
+    pageTitle = Some(pageTitle),
+    headBlock = Some(hmrcHead()),
+    headerBlock = Some(hmrcStandardHeader(
+        serviceUrl = Some(controllers.routes.IndexController.onPageLoad().url)
+    )),
+    beforeContentBlock = Some(accountMenu),
+    scriptsBlock = Some(hmrcScripts()),
+    footerBlock = Some(hmrcStandardFooter())
+)(mainContent)

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -30,29 +30,47 @@
         appConfig: FrontendAppConfig
 )
 
-@(pageTitle: String)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+@(
+        pageTitle: String,
+        timeoutEnabled: Boolean = true,
+        backLinkEnabled: Boolean = true,
+        accountMenuEnabled: Boolean = true)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @accountMenu = {
-    @hmrcAccountMenu(AccountMenu(
-        accountHome = AccountHome(
-            href = appConfig.ptaHomeUrl,
-            active = true
-        ),
-        messages = AccountMessages(
-            href = appConfig.messagesUrl,
-            messageCount = None
-        ),
-        checkProgress = CheckProgress(
-            href = appConfig.trackingHomeUrl
-        ),
-        paperlessSettings = PaperlessSettings(appConfig.paperlessSettingsUrl),
-        personalDetails = PersonalDetails(appConfig.personalDetailsUrl),
-        signOut = SignOut(appConfig.signOutUrl),
-        language = if (messages.lang.code == "cy") Cy else En
-    ))
+    @if(accountMenuEnabled) {
+        @hmrcAccountMenu(AccountMenu(
+            accountHome = AccountHome(
+                href = appConfig.ptaHomeUrl,
+                active = true
+            ),
+            messages = AccountMessages(
+                href = appConfig.messagesUrl,
+                messageCount = None
+            ),
+            checkProgress = CheckProgress(
+                href = appConfig.trackingHomeUrl
+            ),
+            paperlessSettings = PaperlessSettings(appConfig.paperlessSettingsUrl),
+            personalDetails = PersonalDetails(appConfig.personalDetailsUrl),
+            signOut = SignOut(appConfig.signOutUrl),
+            language = if(messages.lang.code == "cy") Cy else En
+        ))
+    }
 
     @hmrcLanguageSelectHelper()
-    @backLink()
+
+    @if(backLinkEnabled) { @backLink() }
+}
+
+@head = {
+    @if(timeoutEnabled) {
+        @hmrcTimeoutDialogHelper(
+            signOutUrl = controllers.routes.SessionExpiredController.onPageLoad().url,
+            message = Some(Messages("timeout.message")),
+            keepAliveButtonText = Some(Messages("timeout.continue")),
+            signOutButtonText = Some(Messages("timeout.exit"))
+        )
+    }
 }
 
 
@@ -63,7 +81,9 @@
 
 @govukLayout(
     pageTitle = Some(pageTitle),
-    headBlock = Some(hmrcHead()),
+    headBlock = Some(hmrcHead(
+        headBlock = Some(head)
+    )),
     headerBlock = Some(hmrcStandardHeader(
         serviceUrl = Some(controllers.routes.IndexController.onPageLoad().url)
     )),

--- a/app/views/anyBenefits.scala.html
+++ b/app/views/anyBenefits.scala.html
@@ -22,10 +22,18 @@
 @import uk.gov.hmrc.renderer.TemplateRenderer
 @import scala.concurrent.ExecutionContext
 
-@this(main_template: main_template, formWithCSRF: FormWithCSRF)
+@this(
+    layout: Layout,
+    pageHeading: hmrcPageHeading,
+    radioButtons: govukRadios,
+    submitButton: playComponents.submit_button,
+    errorSummary: playComponents.error_summary,
+    formWithCSRF: FormWithCSRF,
+    inputRadio: playComponents.input_radio,
+    inputYesNo: playComponents.input_yes_no
+)
 
 @(
-        appConfig: FrontendAppConfig,
         form: Form[_],
         mode: Mode,
         taxYear: SelectTaxYear
@@ -33,41 +41,37 @@
         implicit
         request: Request[_],
         messages: Messages,
-templateRenderer: TemplateRenderer,
 ec: ExecutionContext)
 
-    @title = @{
-        if(form.errors.nonEmpty) messages("site.title.error", messages("anyBenefits.title")) else messages("anyBenefits.title")
+@title = @{
+    if(form.errors.nonEmpty) messages("site.title.error", messages("anyBenefits.heading")) else messages("anyBenefits.heading")
+}
+
+@layout(
+    pageTitle = title
+) {
+    @formWithCSRF(action = AnyBenefitsController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @errorSummary(form.errors)
+
+        @pageHeading(PageHeading(
+            text = messages("anyBenefits.heading"),
+            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
+        ))
+
+        <p class="govuk-body" id="listHeading">@messages("anyBenefits.listHeading")</p>
+
+        @playComponents.list(pageKey = Some("selectBenefits"),
+                         bulletList = Benefits.sortedBenefits.dropRight(1).map(_.toString))
+
+        @inputYesNo(
+            viewModel = InputViewModel("value", form),
+            label = messages("anyBenefits.heading"),
+            labelClass = Some("govuk-visually-hidden"),
+            field = form("value")
+        )
+
+        @submitButton()
     }
+}
 
-    @main_template(
-        title = title,
-        appConfig = appConfig,
-        bodyClasses = None
-    ) {
-
-        @formWithCSRF(action = AnyBenefitsController.onSubmit(mode), 'autoComplete -> "off") {
-
-            @components.back_link()
-
-            @components.error_summary(form.errors)
-
-            @components.heading(messages("anyBenefits.heading"), taxYear = Some(taxYear.asString))
-
-            <p id="listHeading">@messages("anyBenefits.listHeading")</p>
-
-            @components.list(
-                pageKey = Some("selectBenefits"),
-                addCssClass = None,
-                bulletList = Benefits.sortedBenefits.dropRight(1).map(_.toString)
-            )
-
-            @components.input_yes_no(
-                InputViewModel("value", form),
-                label = messages("anyBenefits.heading", taxYear.asString),
-                labelClass = Some("visually-hidden")
-            )
-
-            @components.submit_button()
-        }
-    }

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -22,7 +22,7 @@
 @this(
 uiHead: Head,
 headerNav: HeaderNav,
-footer: Footer,
+footer: uk.gov.hmrc.play.views.html.layouts.Footer,
 servInfo: ServiceInfo,
 mainContHeader: MainContentHeader,
 mainCont: MainContent,

--- a/app/views/howMuchBereavementAllowance.scala.html
+++ b/app/views/howMuchBereavementAllowance.scala.html
@@ -17,12 +17,17 @@
 @import config.FrontendAppConfig
 @import controllers.routes._
 @import models.Mode
-@import viewmodels.InputViewModel
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
-@import uk.gov.hmrc.renderer.TemplateRenderer
-@import scala.concurrent.ExecutionContext
 
-@this(main_template: main_template, formWithCSRF: FormWithCSRF)
+
+@this(
+        layout: Layout,
+        formWithCSRF: FormWithCSRF,
+        errorSummary: playComponents.error_summary,
+        heading: playComponents.heading,
+        govukInput : GovukInput,
+        submitButton: playComponents.submit_button
+)
 
 @(
         appConfig: FrontendAppConfig,
@@ -32,35 +37,35 @@
 )(
         implicit
         request: Request[_],
-        messages: Messages,
-templateRenderer: TemplateRenderer,
-ec: ExecutionContext)
+        messages: Messages
+)
 
 @title = @{
     if(form.errors.nonEmpty) messages("site.title.error", messages("howMuchBereavementAllowance.title")) else messages("howMuchBereavementAllowance.title")
 }
 
-@main_template(
-    title = title,
-    appConfig = appConfig,
-    bodyClasses = None
-) {
 
+@layout( pageTitle = title) {
     @formWithCSRF(action = HowMuchBereavementAllowanceController.onSubmit(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-        @components.back_link()
+        @heading(messages("howMuchBereavementAllowance.heading"), taxYear = Some(taxYear.asString))
 
-        @components.error_summary(form.errors)
-
-        @components.heading(messages("howMuchBereavementAllowance.heading"), taxYear = Some(taxYear.asString))
-
-        @components.input_text(
-            InputViewModel("value", form),
-            label = messages("howMuchBereavementAllowance.heading", taxYear.asString),
-            labelClass = Some("visually-hidden"),
-            currency = true
+        @govukInput(
+            Input(
+                label = Label(
+                    isPageHeading = true,
+                    classes = "govuk-label--xl",
+                    content = Text(messages("howMuchBereavementAllowance.heading", taxYear.asString))
+                ),
+                classes = "govuk-input--width-10",
+                spellcheck = Some(false),
+                prefix = Some(PrefixOrSuffix(
+                    content = Text("£")
+                ))
+            ).withFormField(form("value"))
         )
 
-        @components.submit_button()
+        @submitButton()
     }
 }

--- a/app/views/main_template.scala.html
+++ b/app/views/main_template.scala.html
@@ -122,5 +122,6 @@
 "showPropositionLinks" -> Map(
 "langSelector" -> appConfig.languageTranslationEnabled
 ),
-"inlineScript" -> inlineScript
+"inlineScript" -> inlineScript,
+"signOutUrl" -> appConfig.signOutUrl
 )))

--- a/app/views/playComponents/add_list_row.scala.html
+++ b/app/views/playComponents/add_list_row.scala.html
@@ -1,0 +1,39 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+        name: String,
+        index: Int,
+        mode: Mode
+)(implicit messages: Messages)
+
+
+<li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+    <div id="add-list-@index-answer" class="tabular-data__data tabular-data__data--8-12">@name</div>
+    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+        <a id="add-list-@index-change" href=@routes.OtherTaxableIncomeController.onPageLoad(mode, index)>
+            <span aria-hidden="true">@messages("site.edit")</span>
+            <span class="visually-hidden">@messages("site.hidden-edit", name)</span>
+        </a>
+    </div>
+    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+        <a id="add-list-@index-remove" href=@routes.DeleteOtherController.onPageLoad(mode, Index(index), name, OtherTaxableIncome.collectionId)>
+            <span aria-hidden="true">@messages("site.delete")</span>
+            <span class="visually-hidden">@messages("site.hidden-delete", name)</span>
+        </a>
+    </div>
+</li>
+    

--- a/app/views/playComponents/add_list_summary.scala.html
+++ b/app/views/playComponents/add_list_summary.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+        complete: Seq[(OtherTaxableIncome, Int)],
+        incomplete: Seq[(OtherTaxableIncome, Int)],
+        mode: Mode
+)(implicit messages: Messages)
+
+@if(complete.nonEmpty && incomplete.nonEmpty) {
+    <h2 id="add-to-list-complete-h2">@messages("global.addToList.complete")</h2>
+}
+
+@if(complete.nonEmpty) {
+    <div class="form-group" id="component-answer-list">
+        <ul role="list" class="tabular-data tabular-data--list">
+        @for((otherTaxableIncome, index) <- complete) {
+            @components.add_list_row(otherTaxableIncome.name, index, mode)
+        }
+        </ul>
+    </div>
+}
+
+@if(incomplete.nonEmpty) {
+    <h2 id="add-to-list-incomplete-h2">@messages("global.addToList.incomplete")</h2>
+    <div class="form-group" id="incomplete-component-answer-list">
+        <ul role="list" class="tabular-data tabular-data--list">
+        @for((otherTaxableIncome, index) <- incomplete) {
+            @components.add_list_row(otherTaxableIncome.name, index, mode)
+        }
+        </ul>
+    </div>
+}

--- a/app/views/playComponents/answer_row.scala.html
+++ b/app/views/playComponents/answer_row.scala.html
@@ -1,0 +1,69 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerRow
+
+@(
+row: AnswerRow,
+idPath: String,
+changeLink: Boolean = true
+)(
+implicit messages: Messages
+)
+
+@answerWidth = @{
+if(row.deleteUrl.isDefined) 3 else 5
+}
+
+@if(row.isDeleteLinkRow) {
+<li class="tabular-data__entry tabular-data__entry--grouped">
+    <div class="tabular-data__data tabular-data__data--2-12">
+        <a href=@row.deleteUrl.get>@messages("site.delete.item", row.label.print)</a>
+        <span class="visually-hidden">@messages("site.hidden-delete", row.label.print)</span>
+    </div>
+</li>
+}
+@if(row.isHeadingRow) {
+<li class="tabular-data__entry tabular-data__entry--grouped">
+    <div id="cya-@idPath-heading" class="tabular-data__data tabular-data__data--5-12">
+        <h3 class="heading-small">@row.label.print</h3>
+    </div>
+</li>
+}
+@if(!row.isDeleteLinkRow && !row.isHeadingRow) {
+<li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+    <div id="cya-@idPath-question" class="tabular-data__data tabular-data__data--5-12">@Html(row.label.print)</div>
+    <div id="cya-@idPath-answer" class="tabular-data__data tabular-data__data--@answerWidth-12">@Html(row.answer.print)</div>
+
+    @if(changeLink && row.url.isDefined) {
+    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+        <a id="cya-@idPath-change" href='@row.url'>
+            <span aria-hidden="true">@messages("site.edit")</span>
+            <span class="visually-hidden">@messages(row.changeLabel)</span>
+        </a>
+    </div>
+    }
+
+    @if(row.deleteUrl.isDefined) {
+    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+        <a id="cya-@idPath-remove" href='@row.deleteUrl.get'>
+            <span aria-hidden="true">@messages("site.delete")</span>
+            <span class="visually-hidden">@messages("site.hidden-delete", row.label.print)</span>
+        </a>
+    </div>
+    }
+</li>
+}

--- a/app/views/playComponents/answer_section.scala.html
+++ b/app/views/playComponents/answer_section.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerSection
+@import views.html._
+
+@(
+    answerSection: AnswerSection,
+    idPath: String,
+    changeLink: Boolean = true
+)(
+    implicit messages: Messages
+)
+
+@if(answerSection.headingKey.isDefined){
+
+        <h2 id="cya-@idPath-heading">@messages(answerSection.headingKey.get)</h2>
+
+}
+
+@if(answerSection.rows.nonEmpty) {
+    <ul role="list" class="tabular-data tabular-data--list">
+
+        @for((row, i) <- answerSection.rows.zipWithIndex) {
+            @components.answer_row(row, idPath + "-" + i.toString, changeLink)
+        }
+
+        @if(answerSection.addLinkText.isDefined && answerSection.addLinkUrl.isDefined) {
+            <li class="tabular-data__entry tabular-data__entry--grouped">
+                <div class="tabular-data__data tabular-data__data--2-12">
+                    <a href=@answerSection.addLinkUrl.get>@messages(answerSection.addLinkText.get)</a>
+                </div>
+            </li>
+        }
+    </ul>
+}

--- a/app/views/playComponents/back_link.scala.html
+++ b/app/views/playComponents/back_link.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
+@this(govukBackLink : GovukBackLink)
+
+@()(implicit messages: Messages)
+
+@govukBackLink(BackLink(
+ href = "#",
+ content = Text(messages("site.back")),
+ attributes = Map(
+  "id" -> "back-link"
+ )
+))
+

--- a/app/views/playComponents/button.scala.html
+++ b/app/views/playComponents/button.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+messageKey: String = "",
+inputType: String = "button"
+)(implicit messages: Messages)
+
+<div class="section">
+    <input type="@inputType" class="button" value="@messages(messageKey)" />
+</div>

--- a/app/views/playComponents/button_link.scala.html
+++ b/app/views/playComponents/button_link.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+messageKey: String = "",
+href: String
+)(implicit messages: Messages)
+
+<div class="section">
+    <a href="@href" role="button" class="button">@messages(messageKey)</a>
+</div>

--- a/app/views/playComponents/error_summary.scala.html
+++ b/app/views/playComponents/error_summary.scala.html
@@ -1,0 +1,33 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+        govukErrorSummary : GovukErrorSummary
+)
+
+@(errors: Seq[FormError])(implicit messages: Messages)
+
+@if(errors.nonEmpty) {
+    @govukErrorSummary(ErrorSummary(
+        title       = Text(messages("error.summary.title")),
+        errorList   = for(error <- errors) yield {
+            ErrorLink(
+                href    = Some("#value"),
+                content = Text(messages(error.message, error.args:_*))
+            )
+        }
+    ))
+}

--- a/app/views/playComponents/fieldSet.scala.html
+++ b/app/views/playComponents/fieldSet.scala.html
@@ -1,0 +1,56 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+        field: Field,
+        legend: String,
+        hint: Option[String] = None,
+        hiddenLegend: Boolean = false,
+        inline: Boolean = false,
+        fieldsetClasses: Set[String] = Set.empty,
+        legendClasses: Set[String] = Set("bold-small")
+)(body: Html)(implicit messages: Messages)
+
+@_fieldsetClasses = @{
+    if (inline) {
+        fieldsetClasses + "inline"
+    } else {
+        fieldsetClasses
+    }
+}
+
+@_legendClasses = @{
+    if (hiddenLegend) {
+        legendClasses + "visually-hidden"
+    } else {
+        legendClasses
+    }
+}
+
+<div class="form-group @if(field.hasErrors){ form-group-error }" id="@field.id">
+    <fieldset @if(_fieldsetClasses.nonEmpty){ class="@_fieldsetClasses.mkString(" ")" }>
+        <legend>
+            <span class="@_legendClasses.mkString(" ")">@messages(legend)</span>
+            @field.errors.headOption.map { error =>
+                <span class="error-message">@messages(error.message, error.args: _*)</span>
+            }
+            @hint.map { hint =>
+                <span class="form-hint">@messages(hint)</span>
+            }
+        </legend>
+        @body
+    </fieldset>
+</div>

--- a/app/views/playComponents/ga_noscript.scala.html
+++ b/app/views/playComponents/ga_noscript.scala.html
@@ -1,0 +1,22 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@()
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NDJKHWK"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+

--- a/app/views/playComponents/heading.scala.html
+++ b/app/views/playComponents/heading.scala.html
@@ -1,31 +1,30 @@
 @*
- * Copyright 2021 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 
 @this()
 
 @(
-    heading: String,
-    headingSize: String = "heading-xlarge",
-    taxYear: Option[String] = None
+        heading: String,
+        headingSize: String = "heading-xlarge",
+        taxYear: Option[String] = None
 )(implicit messages: Messages)
 
-@secondaryHeaderText = @{
-    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
-}
+ @secondaryHeaderText = @{
+  if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
+ }
 
-<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
-<h1 class="govuk-fieldset__heading">@heading</h1>
+ <span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
 

--- a/app/views/playComponents/heading.scala.html
+++ b/app/views/playComponents/heading.scala.html
@@ -27,4 +27,5 @@
 }
 
 <span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
+<h1 class="govuk-fieldset__heading">@heading</h1>
 

--- a/app/views/playComponents/heading.scala.html
+++ b/app/views/playComponents/heading.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(
+    heading: String,
+    headingSize: String = "heading-xlarge",
+    taxYear: Option[String] = None
+)(implicit messages: Messages)
+
+@secondaryHeaderText = @{
+    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
+}
+
+<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
+

--- a/app/views/playComponents/headingWithCaption.scala.html
+++ b/app/views/playComponents/headingWithCaption.scala.html
@@ -1,0 +1,31 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(
+    heading: String,
+    headingSize: String = "heading-xlarge",
+    taxYear: Option[String] = None
+)(implicit messages: Messages)
+
+@secondaryHeaderText = @{
+    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
+}
+
+<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
+<h1 class="govuk-fieldset__heading">@heading</h1>
+

--- a/app/views/playComponents/input_check_box.scala.html
+++ b/app/views/playComponents/input_check_box.scala.html
@@ -1,0 +1,54 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+        field: Field,
+        legend: String,
+        legendClass: Option[String] = None,
+        hint: Option[String] = None,
+        trackGa: Boolean = false,
+        inputs: Seq[(String, String)]
+)(implicit messages: Messages)
+
+<div class="form-group @if(field.hasErrors){form-field--error}">
+    <fieldset id="@{field.id}">
+        <legend class="bold-small @legendClass">@legend</legend>
+        @hint.map { hint =>
+            <span class="form-hint">
+                @hint
+            </span>
+        }
+        @field.errors.map { error =>
+            <span class="error-notification" id="error-message-@field.id-input">
+            @messages(error.message, error.args: _*)
+            </span>
+        }
+        @for(((label, v), i) <- inputs.zipWithIndex) {
+            @defining(
+                inputs.indices.flatMap { j =>
+                    field(s"[$j]").value
+                }
+            ) { answers =>
+                <div class="multiple-choice">
+                    <input id="@field(s"[$i]").id" type="checkbox" name="@field(s"[$i]").name" value="@v" @if(answers.contains(v)){ checked="checked"} @if(trackGa){data-journey-click="childcare-calculator-frontend:click:@field(s"[$i]").id"} />
+                    <label for="@field(s"[$i]").id">
+                    @messages(label).capitalize
+                    </label>
+                </div>
+            }
+        }
+    </fieldset>
+</div>

--- a/app/views/playComponents/input_check_box.scala.html
+++ b/app/views/playComponents/input_check_box.scala.html
@@ -14,41 +14,29 @@
  * limitations under the License.
  *@
 
-@(
-        field: Field,
-        legend: String,
-        legendClass: Option[String] = None,
-        hint: Option[String] = None,
-        trackGa: Boolean = false,
-        inputs: Seq[(String, String)]
-)(implicit messages: Messages)
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import viewmodels.InputViewModelBase
 
-<div class="form-group @if(field.hasErrors){form-field--error}">
-    <fieldset id="@{field.id}">
-        <legend class="bold-small @legendClass">@legend</legend>
-        @hint.map { hint =>
-            <span class="form-hint">
-                @hint
-            </span>
-        }
-        @field.errors.map { error =>
-            <span class="error-notification" id="error-message-@field.id-input">
-            @messages(error.message, error.args: _*)
-            </span>
-        }
-        @for(((label, v), i) <- inputs.zipWithIndex) {
-            @defining(
-                inputs.indices.flatMap { j =>
-                    field(s"[$j]").value
-                }
-            ) { answers =>
-                <div class="multiple-choice">
-                    <input id="@field(s"[$i]").id" type="checkbox" name="@field(s"[$i]").name" value="@v" @if(answers.contains(v)){ checked="checked"} @if(trackGa){data-journey-click="childcare-calculator-frontend:click:@field(s"[$i]").id"} />
-                    <label for="@field(s"[$i]").id">
-                    @messages(label).capitalize
-                    </label>
-                </div>
-            }
-        }
-    </fieldset>
-</div>
+@this(govukCheckboxes : GovukCheckboxes)
+
+@(
+viewModel: InputViewModelBase,
+legend: String,
+legendClass: Option[String] = None,
+hint: Option[String] = None,
+trackGa: Boolean = false,
+inputs: Seq[CheckboxItem],
+field: Field)(implicit messages: Messages)
+
+@govukCheckboxes(
+            Checkboxes(
+                fieldset = Some(Fieldset(
+                  legend = Some(Legend(
+                    content = Text(legend),
+                    classes = "govuk-fieldset__legend--l",
+                    isPageHeading = true
+                  ))
+                )),
+        items = inputs,
+    ).withFormField(field)
+)

--- a/app/views/playComponents/input_date.scala.html
+++ b/app/views/playComponents/input_date.scala.html
@@ -1,0 +1,69 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+id: String,
+label: String,
+legendClass: String = "",
+errorKey: String,
+dayErrorKey: String,
+monthErrorKey: String,
+yearErrorKey: String,
+valueDay: Option[String] = None,
+valueMonth: Option[String] = None,
+valueYear: Option[String] = None,
+secondaryLabel: Option[String] = None,
+hint: Option[String] = None
+)(implicit messages: Messages)
+
+<div class="form-field @if(errorKey.nonEmpty || dayErrorKey.nonEmpty || monthErrorKey.nonEmpty || yearErrorKey.nonEmpty){form-field--error}">
+    <fieldset>
+        <legend>
+        <span class="form-label bold @if(legendClass.nonEmpty){@legendClass}">
+          @label
+        </span>
+        @if(hint.nonEmpty){
+            <span class="form-hint" id="@{id}-date-hint">@hint</span>
+        }
+            @if(errorKey.nonEmpty){
+                <span class="error-notification" id="error-message-@{id}-date">@messages(errorKey)</span>
+            }
+            @if(dayErrorKey.nonEmpty){
+                <span class="error-notification" id="error-message-@{id}-day">@messages(dayErrorKey)</span>
+            }
+            @if(monthErrorKey.nonEmpty){
+                <span class="error-notification" id="error-message-@{id}-month">@messages(monthErrorKey)</span>
+            }
+            @if(yearErrorKey.nonEmpty){
+                <span class="error-notification" id="error-message-@{id}-year">@messages(yearErrorKey)</span>
+            }
+        </legend>
+        <div class="form-date">
+            <div class="form-group form-group-day">
+                <label class="form-label bold" for="@{id}.day">@messages("date.day")</label>
+                <input class="form-control" id="@{id}.day" name="@{id}.day" type="number" min="1" max="31" aria-describedby="@if(dayErrorKey.nonEmpty){error-message-@{id}-day} else {@{id}-date-hint}" value="@valueDay" />
+            </div>
+            <div class="form-group form-group-month">
+                <label class="form-label bold" for="@{id}.month">@messages("date.month")</label>
+                <input class="form-control" id="@{id}.month" name="@{id}.month" type="number" min="1" max="12" @if(monthErrorKey.nonEmpty){aria-describedby="error-message-@{id}-month" } value="@valueMonth" />
+            </div>
+            <div class="form-group form-group-year">
+                <label class="form-label bold" for="@{id}.year">@messages("date.year")</label>
+                <input class="form-control" id="@{id}.year" name="@{id}.year" type="number" min="1900" max="2050" @if(yearErrorKey.nonEmpty){aria-describedby="error-message-@{id}-year" } value="@valueYear" />
+            </div>
+        </div>
+    </fieldset>
+</div>

--- a/app/views/playComponents/input_radio.scala.html
+++ b/app/views/playComponents/input_radio.scala.html
@@ -1,0 +1,41 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputViewModelBase
+
+@this(govukRadios : GovukRadios)
+
+@(
+    viewModel: InputViewModelBase,
+    legend: String,
+    legendClass: Option[String] = None,
+    hint: Option[String] = None,
+    trackGa: Boolean = false,
+    inputs: Seq[RadioItem],
+    field: Field)(implicit messages: Messages)
+
+@govukRadios(
+    Radios(
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(legend),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            ))
+        )),
+        items = inputs
+    ).withFormField(field)
+)

--- a/app/views/playComponents/input_radio.scala.html
+++ b/app/views/playComponents/input_radio.scala.html
@@ -20,20 +20,21 @@
 
 @(
     viewModel: InputViewModelBase,
-    legend: String,
+    legend: Html,
     legendClass: Option[String] = None,
     hint: Option[String] = None,
     trackGa: Boolean = false,
     inputs: Seq[RadioItem],
     field: Field)(implicit messages: Messages)
 
+
 @govukRadios(
     Radios(
         fieldset = Some(Fieldset(
             legend = Some(Legend(
-                content = Text(legend),
                 classes = "govuk-fieldset__legend--xl",
-                isPageHeading = true
+                content = HtmlContent(legend),
+                isPageHeading = false
             ))
         )),
         items = inputs

--- a/app/views/playComponents/input_text.scala.html
+++ b/app/views/playComponents/input_text.scala.html
@@ -1,0 +1,63 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputViewModelBase
+
+@(
+        viewModel: InputViewModelBase,
+        label: String,
+        divClass: Option[String] = None,
+        inputClass: Option[String] = None,
+        hintLine1: Option[String] = None,
+        hintLine2: Option[String] = None,
+        labelClass: Option[String] = None,
+        currency: Boolean = false,
+        inputType: Option[String] = Some("text"),
+        valueError: Boolean = false,
+        autoComplete: Boolean = false
+)(implicit messages: Messages)
+
+<div class="form-group @if(divClass.nonEmpty){@divClass} @if(viewModel.errorKey.nonEmpty){form-field--error}">
+    <label class="form-label" for="@{viewModel.id}">
+        <span class="bold @if(labelClass.nonEmpty){@labelClass}">@label</span>
+        @if(hintLine1.nonEmpty){
+        <span class="form-hint">@hintLine1</span>
+        }
+        @if(hintLine2.nonEmpty){
+        <span id="hint-line-2" class="form-hint">@hintLine2</span>
+        }
+        @if(viewModel.errorKey.nonEmpty && !valueError){
+        <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>
+        }
+        @if(viewModel.errorKey.nonEmpty && valueError){
+        <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey, viewModel.value.getOrElse(""))</span>
+        }
+    </label>
+    <div class="form-control-wrapper">
+        @if(currency){
+            <span class="govuk-currency-input__inner__unit">£</span>
+        }
+        <input
+            class="form-control @if(currency){govuk-currency-input__inner__input} @inputClass"
+            type=@inputType
+            id="@{viewModel.id}"
+            name="@{viewModel.id}"
+            value="@{viewModel.value}"
+            @if(autoComplete){autocomplete="tel"}
+            @if(viewModel.errorKey.nonEmpty){aria-describedby="error-message-@{viewModel.id}-input"}
+        />
+    </div>
+</div>

--- a/app/views/playComponents/input_textarea.scala.html
+++ b/app/views/playComponents/input_textarea.scala.html
@@ -1,0 +1,48 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputViewModelBase
+
+@(
+viewModel: InputViewModelBase,
+label: String,
+secondaryLabel: Option[String] = None,
+inputClass: Option[String] = None,
+hint: Option[String] = None,
+charLimit: Option[Int] = None,
+labelClass: Option[String] = None
+)(implicit messages: Messages)
+
+<div class="form-group @if(viewModel.errorKey != ""){form-field--error}">
+    <label class="form-label" for="@{viewModel.id}">
+        <span class="bold @if(labelClass.nonEmpty){@labelClass}">@label</span>
+        @if(hint.get != ""){
+        <span class="form-hint">@hint</span>
+        }
+        @if(viewModel.errorKey != ""){
+        <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>
+        }
+    </label>
+        <textarea
+                class="form-control form-control--full-width @inputClass"
+                id="@{viewModel.id}"
+                name="@{viewModel.id}"
+                value="@{viewModel.value}"
+                @if(viewModel.errorKey.nonEmpty){aria-describedby="error-message-@{viewModel.id}-input"}
+                rows="5"
+        >@{viewModel.value}</textarea>
+</div>
+

--- a/app/views/playComponents/input_yes_no.scala.html
+++ b/app/views/playComponents/input_yes_no.scala.html
@@ -1,0 +1,53 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputViewModelBase
+
+@(
+viewModel: InputViewModelBase,
+label: String,
+secondaryLabel: Option[String] = None,
+inputClass: Option[String] = None,
+hint: Option[String] = None,
+yesAssoc: Option[String] = None,
+noAssoc: Option[String] = None,
+labelClass: Option[String] = None
+)(implicit messages: Messages)
+
+
+<div class="form-group @if(viewModel.errorKey.nonEmpty){form-field--error}">
+    <fieldset class="inline" id="@{viewModel.id}">
+
+        <legend>
+          <span @if(labelClass.nonEmpty){class="@labelClass"}>@label</span>
+          @if(hint.nonEmpty){
+            <span class="form-hint">@hint</span>
+          }
+          @if(viewModel.errorKey.nonEmpty){
+            <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>
+          }
+        </legend>
+        <div class="multiple-choice" data-target="@if(yesAssoc.nonEmpty){@yesAssoc}">
+            <input id="@{viewModel.id}-yes" type="radio" name="@{viewModel.id}" value="true" @if(viewModel.value.contains("true")){checked="checked"} />
+            <label for="@{viewModel.id}-yes" > @messages("site.yes") </label>
+        </div>
+        <div class="multiple-choice" data-target="@if(noAssoc.nonEmpty){@noAssoc}">
+            <input id="@{viewModel.id}-no" type="radio" name="@{viewModel.id}" value="false" @if(viewModel.value.contains("false")){checked="checked"} />
+            <label for="@{viewModel.id}-no" > @messages("site.no") </label>
+        </div>
+
+    </fieldset>
+</div>

--- a/app/views/playComponents/input_yes_no.scala.html
+++ b/app/views/playComponents/input_yes_no.scala.html
@@ -15,39 +15,28 @@
  *@
 
 @import viewmodels.InputViewModelBase
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
+@this(govukRadios : GovukRadios)
 
 @(
-viewModel: InputViewModelBase,
-label: String,
-secondaryLabel: Option[String] = None,
-inputClass: Option[String] = None,
-hint: Option[String] = None,
-yesAssoc: Option[String] = None,
-noAssoc: Option[String] = None,
-labelClass: Option[String] = None
+    viewModel: InputViewModelBase,
+    label: String,
+    hint: Option[String] = None,
+    labelClass: Option[String] = None,
+    field: Field
 )(implicit messages: Messages)
-
-
-<div class="form-group @if(viewModel.errorKey.nonEmpty){form-field--error}">
-    <fieldset class="inline" id="@{viewModel.id}">
-
-        <legend>
-          <span @if(labelClass.nonEmpty){class="@labelClass"}>@label</span>
-          @if(hint.nonEmpty){
-            <span class="form-hint">@hint</span>
-          }
-          @if(viewModel.errorKey.nonEmpty){
-            <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>
-          }
-        </legend>
-        <div class="multiple-choice" data-target="@if(yesAssoc.nonEmpty){@yesAssoc}">
-            <input id="@{viewModel.id}-yes" type="radio" name="@{viewModel.id}" value="true" @if(viewModel.value.contains("true")){checked="checked"} />
-            <label for="@{viewModel.id}-yes" > @messages("site.yes") </label>
-        </div>
-        <div class="multiple-choice" data-target="@if(noAssoc.nonEmpty){@noAssoc}">
-            <input id="@{viewModel.id}-no" type="radio" name="@{viewModel.id}" value="false" @if(viewModel.value.contains("false")){checked="checked"} />
-            <label for="@{viewModel.id}-no" > @messages("site.no") </label>
-        </div>
-
-    </fieldset>
-</div>
+    @govukRadios(Radios(
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(content = Text(label),
+                classes = s"""govuk-fieldset__legend--l ${labelClass.getOrElse("")}""",
+                isPageHeading = true
+            ))
+        )),
+        hint = hint.map(hintString => Hint(content = Text(hintString))),
+        items = Seq("yes", "no").map(answer =>
+            RadioItem(value = Some((answer == "yes").toString),
+                      content = Text(messages(s"site.$answer"))
+        )),
+        classes = "govuk-radios--inline"
+    ).withFormField(field))

--- a/app/views/playComponents/input_yes_no_with_text_expander.scala.html
+++ b/app/views/playComponents/input_yes_no_with_text_expander.scala.html
@@ -1,0 +1,75 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.{InputViewModelBase, InputViewModel}
+
+@(
+viewModel: InputViewModelBase,
+form: Form[_],
+label: String,
+textFieldLabel: String,
+textFieldLabelId: String = "yesAnyTaxPaid",
+textFieldId: String = "taxPaidAmount",
+secondaryLabel: Option[String] = None,
+inputClass: Option[String] = None,
+hint: Option[String] = None,
+yesAssoc: Option[String] = None,
+noAssoc: Option[String] = None,
+labelClass: Option[String] = None,
+textHintLine1: Option[String] = None,
+textHintLine2: Option[String] = None,
+currency: Boolean = false,
+inputType: Option[String] = Some("text"),
+autoComplete: Boolean = false
+)(implicit messages: Messages)
+
+
+<div class="form-group @if(viewModel.errorKey.nonEmpty){form-field--error}">
+    <fieldset class="inline" id="@{viewModel.id}">
+
+        <legend>
+          <span @if(labelClass.nonEmpty){class="@labelClass"}>@label</span>
+          @if(hint.nonEmpty){
+            <span class="form-hint">@hint</span>
+          }
+          @if(viewModel.errorKey.nonEmpty){
+            <span class="error-notification" id="error-message-@{viewModel.id}-input">@messages(viewModel.errorKey)</span>
+          }
+        </legend>
+        <div class="multiple-choice" data-target="@if(yesAssoc.nonEmpty){@yesAssoc}">
+            <input id="@{viewModel.id}-yes" type="radio" name="@{viewModel.id}" value="true" @if(viewModel.value.contains("true")){checked="checked"} />
+            <label for="@{viewModel.id}-yes" > @messages("site.yes") </label>
+        </div>
+        <div class="multiple-choice" data-target="@if(noAssoc.nonEmpty){@noAssoc}">
+            <input id="@{viewModel.id}-no" type="radio" name="@{viewModel.id}" value="false" @if(viewModel.value.contains("false")){checked="checked"} />
+            <label for="@{viewModel.id}-no" > @messages("site.no") </label>
+        </div>
+
+        <div id="@textFieldLabelId" class="js-hidden">
+            @components.input_text(InputViewModel(textFieldId, form),
+            textFieldLabel,
+            Some("panel panel-border-narrow"),
+            hintLine1 = textHintLine1,
+            hintLine2 = textHintLine2,
+            currency = currency,
+            inputType = inputType,
+            autoComplete = autoComplete
+            )
+        </div>
+
+    </fieldset>
+
+</div>

--- a/app/views/playComponents/language_selector.scala.html
+++ b/app/views/playComponents/language_selector.scala.html
@@ -1,0 +1,44 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+
+
+@(appConfig: FrontendAppConfig)(implicit messages: Messages)
+
+<div class="float--right">
+<nav aria-label="@messages("language-switcher.nav")" class="language-switcher">
+<ul>
+    <li>
+        @if(messages.lang == Lang("en")) {
+        <span>@messages("language-switcher.english")</span>
+        <span aria-hidden="true"> | </span>
+        <a id="switch-language" href="@appConfig.routeToSwitchLanguage("cymraeg")" data-journey-click="link - click:Language selector:Welsh">
+            <span class="visuallyhidden">@messages("language-switcher.welsh.hover")</span>
+            <span aria-hidden="true">@messages("language-switcher.welsh")</span>
+        </a>
+        } else {
+
+        <a id="switch-language" href="@appConfig.routeToSwitchLanguage("english")" data-journey-click="link - click:Language selector:English">
+            <span class="visuallyhidden">@messages("language-switcher.english.hover")</span>
+            <span aria-hidden="true">@messages("language-switcher.english")</span></a>
+        <span aria-hidden="true"> | </span>
+        <span>@messages("language-switcher.welsh")</span>
+        }
+    </li>
+</ul>
+</nav>
+</div>

--- a/app/views/playComponents/list.scala.html
+++ b/app/views/playComponents/list.scala.html
@@ -29,7 +29,7 @@
 }
 
 @list = {
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
         @for(bullet <- bulletList) {
             <li id="bullet-@bullet">@text(bullet)</li>
         }

--- a/app/views/playComponents/list.scala.html
+++ b/app/views/playComponents/list.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+    pageKey: Option[String] = None,
+    addCssClass: Option[String] = None,
+    bulletList: Seq[String]
+)(implicit messages: Messages)
+
+@cssClass = @{
+    if(addCssClass.isDefined) s"form-group ${addCssClass.get}" else "form-group"
+}
+
+@text(bullet: String) = @{
+    if(pageKey.isDefined) messages(s"${pageKey.get}.$bullet") else bullet
+}
+
+@list = {
+    <ul class="list list-bullet">
+        @for(bullet <- bulletList) {
+            <li id="bullet-@bullet">@text(bullet)</li>
+        }
+    </ul>
+}
+
+@single = {
+    <p id="bullet-@{bulletList.head}">@text(bulletList.head)</p>
+}
+
+<div class="@cssClass" id="component-bullet-list">
+    @if(bulletList.size == 1) {
+        @single
+    } else {
+        @list
+    }
+</div>

--- a/app/views/playComponents/other_summary.scala.html
+++ b/app/views/playComponents/other_summary.scala.html
@@ -1,0 +1,40 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerRow
+
+
+@(
+    addCssClass: Option[String] = None,
+    answers: Seq[AnswerRow]
+)(implicit messages: Messages)
+
+@cssClass = @{
+    if(addCssClass.isDefined) s"form-group ${addCssClass.get}" else "form-group"
+}
+
+<div class="@cssClass" id="component-answer-list">
+    <ul role="list" class="tabular-data tabular-data--list">
+        @for((answer, i) <- answers.zipWithIndex) {
+                @components.answer_row(
+                    row = answer,
+                    idPath = s"other_summary_$i"
+                    )
+        }
+
+
+    </ul>
+</div>

--- a/app/views/playComponents/pdf_answer_row.scala.html
+++ b/app/views/playComponents/pdf_answer_row.scala.html
@@ -1,0 +1,35 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerRow
+
+@(
+        row: AnswerRow
+)(
+        implicit messages: Messages
+)
+@if(row.isHeadingRow) {
+<li>
+    <h3>@row.label.print</h3>
+</li>
+}
+@if(!row.isHeadingRow) {
+<li>
+    <div>@Html(row.label.print)</div>
+    <div>@Html(row.answer.print)</div>
+</li>
+}
+

--- a/app/views/playComponents/pdf_answer_section.scala.html
+++ b/app/views/playComponents/pdf_answer_section.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerSection
+@import views.html._
+
+@(
+    answerSection: AnswerSection
+)(
+    implicit messages: Messages
+)
+
+@if(answerSection.headingKey.isDefined){
+    <h2>@messages(answerSection.headingKey.get)</h2>
+}
+@if(answerSection.rows.nonEmpty) {
+    <ul>
+
+        @for((row, i) <- answerSection.rows.zipWithIndex) {
+            @components.pdf_answer_row(row)
+        }
+    </ul>
+}

--- a/app/views/playComponents/submit_button.scala.html
+++ b/app/views/playComponents/submit_button.scala.html
@@ -1,0 +1,25 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
+@this(govukButton : GovukButton)
+
+@(submitText: String = "site.continue")(implicit messages: Messages)
+
+@govukButton(Button(
+ content = Text(messages(submitText))
+))

--- a/app/views/selectBenefits.scala.html
+++ b/app/views/selectBenefits.scala.html
@@ -19,10 +19,17 @@
 @import forms.SelectBenefitsForm
 @import models.Mode
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
-@import uk.gov.hmrc.renderer.TemplateRenderer
-@import scala.concurrent.ExecutionContext
+@import viewmodels.InputViewModel
 
-@this(main_template: main_template, formWithCSRF: FormWithCSRF)
+
+@this(
+    formWithCSRF: FormWithCSRF,
+    layout: Layout,
+    errorSummary: playComponents.error_summary,
+    heading: playComponents.heading,
+    inputCheckBox: playComponents.input_check_box,
+    submitButton: playComponents.submit_button
+)
 
 @(
         appConfig: FrontendAppConfig,
@@ -32,35 +39,38 @@
 )(
         implicit
         request: Request[_],
-        messages: Messages,
-templateRenderer: TemplateRenderer,
-ec: ExecutionContext)
+        messages: Messages
+)
 
 @title = @{
     if(form.errors.nonEmpty) messages("site.title.error", messages("selectBenefits.title")) else messages("selectBenefits.title")
 }
 
-@main_template(
-    title = title,
-    appConfig = appConfig,
-    bodyClasses = None
+@layout(
+    pageTitle = title
 ) {
 
     @formWithCSRF(action = SelectBenefitsController.onSubmit(mode), 'autoComplete -> "off") {
 
-        @components.back_link()
+        @errorSummary(form.errors)
 
-        @components.error_summary(form.errors)
+        @heading(messages("selectBenefits.heading"), taxYear = Some(taxYear.asString))
 
-        @components.heading(messages("selectBenefits.heading"), taxYear = Some(taxYear.asString))
-
-        @components.input_check_box(
-            form("value"),
+        @inputCheckBox(
+            viewModel = InputViewModel("value", form),
             legend = messages("selectBenefits.heading", taxYear.asString),
             legendClass = Some("visually-hidden"),
-            inputs = SelectBenefitsForm.options
+            inputs = Benefits.sortedBenefits.map { checkboxOption =>
+                CheckboxItem(
+                    content = HtmlContent(messages(s"selectBenefits.$checkboxOption")),
+                    value = checkboxOption.toString
+                )
+            },
+            field = form("value")
         )
 
-        @components.submit_button()
+        @submitButton()
+
     }
+
 }

--- a/app/views/selectTaxYear.scala.html
+++ b/app/views/selectTaxYear.scala.html
@@ -18,11 +18,18 @@
 @import controllers.routes._
 @import models.Mode
 @import viewmodels.InputViewModel
-@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import uk.gov.hmrc.renderer.TemplateRenderer
 @import scala.concurrent.ExecutionContext
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 
-@this(main_template: main_template, formWithCSRF: FormWithCSRF)
+@this(
+        formWithCSRF: FormWithCSRF,
+        heading: playComponents.heading,
+        inputRadio: playComponents.input_radio,
+        submitButton: playComponents.submit_button,
+        errorSummary: playComponents.error_summary,
+        layout: Layout
+)
 
 @(
         appConfig: FrontendAppConfig,
@@ -31,14 +38,40 @@
 )(
         implicit
         request: Request[_],
-        messages: Messages,
-templateRenderer: TemplateRenderer,
-ec: ExecutionContext)
+        messages: Messages)
 
 @title = @{
     if(form.errors.nonEmpty) messages("site.title.error", messages("selectTaxYear.title")) else messages("selectTaxYear.title")
 }
 
+@layout(
+    pageTitle = title
+) {
+    @formWithCSRF(action = SelectTaxYearController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @errorSummary(form.errors)
+
+        @heading(messages("selectTaxYear.heading"))
+
+        @inputRadio(
+            viewModel = InputViewModel("value", form),
+            legend = messages("selectTaxYear.heading"),
+            legendClass = Some("visually-hidden"),
+            inputs = SelectTaxYear.options map { radioOption =>
+                RadioItem(
+                    id = Some(radioOption.id),
+                    value = Some(radioOption.value),
+                    content = HtmlContent(radioOption.message.html)
+                )
+            },
+            field = form("value")
+        )
+
+        @submitButton()
+    }
+}
+
+@*
 @main_template(
     title = title,
     appConfig = appConfig,
@@ -62,3 +95,4 @@ ec: ExecutionContext)
         @components.submit_button()
     }
 }
+*@

--- a/app/views/selectTaxYear.scala.html
+++ b/app/views/selectTaxYear.scala.html
@@ -22,7 +22,7 @@
 
 @this(
         formWithCSRF: FormWithCSRF,
-        heading: playComponents.heading,
+        heading: playComponents.headingWithCaption,
         inputRadio: playComponents.input_radio,
         submitButton: playComponents.submit_button,
         errorSummary: playComponents.error_summary,

--- a/app/views/selectTaxYear.scala.html
+++ b/app/views/selectTaxYear.scala.html
@@ -18,8 +18,6 @@
 @import controllers.routes._
 @import models.Mode
 @import viewmodels.InputViewModel
-@import uk.gov.hmrc.renderer.TemplateRenderer
-@import scala.concurrent.ExecutionContext
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 
 @this(
@@ -51,12 +49,10 @@
 
         @errorSummary(form.errors)
 
-        @heading(messages("selectTaxYear.heading"))
-
         @inputRadio(
             viewModel = InputViewModel("value", form),
-            legend = messages("selectTaxYear.heading"),
-            legendClass = Some("visually-hidden"),
+            legend = heading(messages("selectTaxYear.heading")),
+            legendClass = None,
             inputs = SelectTaxYear.options map { radioOption =>
                 RadioItem(
                     id = Some(radioOption.id),
@@ -71,28 +67,3 @@
     }
 }
 
-@*
-@main_template(
-    title = title,
-    appConfig = appConfig,
-    bodyClasses = None
-) {
-    @formWithCSRF(action = SelectTaxYearController.onSubmit(mode), 'autoComplete -> "off") {
-
-        @components.back_link()
-
-        @components.error_summary(form.errors)
-
-        @components.heading(messages("selectTaxYear.heading"))
-
-        @components.input_radio(
-            viewModel = InputViewModel("value", form),
-            legend = messages("selectTaxYear.heading"),
-            legendClass = Some("visually-hidden"),
-            inputs = SelectTaxYear.options
-        )
-
-        @components.submit_button()
-    }
-}
-*@

--- a/app/views/session_expired.scala.html
+++ b/app/views/session_expired.scala.html
@@ -15,27 +15,33 @@
  *@
 
 @import config.FrontendAppConfig
-@import uk.gov.hmrc.renderer.TemplateRenderer
-@import scala.concurrent.ExecutionContext
 
-@this(main_template: main_template)
+
+@this(
+        layout: Layout,
+        govukButton : GovukButton
+)
 
 @(
         appConfig: FrontendAppConfig
 )(
         implicit
         request: Request[_],
-        messages: Messages,
-templateRenderer: TemplateRenderer,
-ec: ExecutionContext)
+        messages: Messages
+)
 
-@main_template(
-    title = messages("session_expired.title"),
-    appConfig = appConfig,
-    bodyClasses = None,
-    timeout = false
+@layout(
+    pageTitle=messages("session_expired.title"),
+    timeoutEnabled = false,
+    backLinkEnabled = false,
+    accountMenuEnabled = false
 ) {
-    <h1 class="heading-xlarge">@messages("session_expired.heading")</h1>
+    <h1 class="govuk-heading-xl">@messages("session_expired.heading")</h1>
 
-    <a href=/claim-tax-refund class="button" role="button">@messages("session_expired.button")</a>
+    <div class="govuk-button-group">
+        @govukButton(Button(
+            href = Some(controllers.routes.IndexController.onPageLoad().url),
+            content = Text(messages("session_expired.button"))
+        ))
+    </div>
 }

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val playSettings: Seq[Setting[_]] = Seq.empty
 val compile = Seq(
   ws,
   "uk.gov.hmrc"           %% "bootstrap-frontend-play-28"     % "5.3.0",
+  "uk.gov.hmrc"           %% "play-frontend-hmrc"             % "0.82.0-play-28",
   "uk.gov.hmrc"           %% "simple-reactivemongo"           % "8.0.0-play-28",
   "uk.gov.hmrc"           %% "local-template-renderer"        % "2.15.0-play-28" excludeAll(ExclusionRule(organization="org.scalactic")),
   "uk.gov.hmrc"           %% "govuk-template"                 % "5.68.0-play-28",
@@ -28,7 +29,7 @@ val compile = Seq(
   "uk.gov.hmrc"           %% "tax-year"                       % "1.3.0",
   "org.scalatra.scalate"  %% "play-scalate"                   % "0.6.0",
   "org.scalatra.scalate"  %% "scalate-core"                   % "1.9.6",
-  "uk.gov.hmrc"           %% "domain"                         % "5.11.0-play-27",
+  "uk.gov.hmrc"           %% "domain"                         % "5.11.0-play-27"
 )
 
 def test(scope: String = "test"): Seq[ModuleID] = Seq(
@@ -95,6 +96,15 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(majorVersion := 0)
   .settings(scalaVersion := "2.12.12")
+  .settings(
+    TwirlKeys.templateImports ++= Seq(
+      "uk.gov.hmrc.govukfrontend.views.html.components._",
+      "uk.gov.hmrc.govukfrontend.views.html.helpers._",
+      "uk.gov.hmrc.hmrcfrontend.views.html.components._",
+      "uk.gov.hmrc.hmrcfrontend.views.html.helpers._",
+      "uk.gov.hmrc.govukfrontend.views.html.components.implicits._"
+    )
+  )
 // ***************
 // Use the silencer plugin to suppress warnings from unused imports in compiled twirl templates
 scalacOptions += "-P:silencer:pathFilters=routes"
@@ -104,3 +114,5 @@ libraryDependencies ++= Seq(
   "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full
 )
 // ***************
+
+

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,6 @@
-# microservice specific routes
+
+->         /govuk-frontend                     govuk.Routes
+->         /hmrc-frontend                      hmrcfrontend.Routes
 
 GET        /                                                                controllers.IndexController.onPageLoad
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,6 +76,26 @@ microservice {
         port = 9869
       }
 
+      pertax-frontend {
+        host = localhost
+        port = 9232
+        urls {
+            home = "/personal-account"
+            messages = "/personal-account/messages"
+            paperlessSettings = "/personal-account/preferences"
+            personalDetails = "/personal-account/personal-details"
+            signOut = "/personal-account/signout?continueUrl=%2Ffeedback%2FCTR"
+        }
+      }
+
+      tracking-frontend {
+        host = localhost
+        port = 9100
+        urls {
+            home = "/track"
+        }
+      }
+
       address-lookup-frontend {
         host = localhost
         port = 9028
@@ -174,3 +194,5 @@ identity-verification-uplift {
 }
 
 accessibility-statement.service-path = "/claim-a-tax-refund"
+
+contact-frontend.serviceId = "claimtaxrefundfrontend"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,7 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%green(%date{ISO8601}) %gray(level=)[%highlight(%level)] %gray(message=[%yellow(%message)]) %gray(logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] sid=[%X{X-Session-ID}] user=[%X{Authorization}]) %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%green(%date{ISO8601}) %gray(level=)[%highlight(%level)] %gray(message=[%yellow(%message)])  %gray(logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}]) %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 

--- a/conf/messages
+++ b/conf/messages
@@ -1,3 +1,5 @@
+service.name = Claim a tax refund
+
 error.boolean = Please give an answer
 error.invalid_date = Give a correct date
 error.date.day_blank = Enter a day

--- a/conf/messages
+++ b/conf/messages
@@ -291,11 +291,11 @@ selectBenefits.title = Which taxable benefits did you get?
 selectBenefits.heading = Which taxable benefits did you get?
 selectBenefits.changeLabel = Change Change which taxable benefits you got
 selectBenefits.blank = Select the taxable benefits you got
-selectBenefits.jobseekers-allowance = contribution-based Jobseeker’s Allowance
+selectBenefits.jobseekers-allowance = Contribution-based Jobseeker’s Allowance
 selectBenefits.incapacity-benefit = Incapacity Benefit
 selectBenefits.employment-and-support-allowance = Employment and Support Allowance
 selectBenefits.state-pension = State Pension
-selectBenefits.other-taxable-benefit = other taxable benefit
+selectBenefits.other-taxable-benefit = Other taxable benefit
 selectBenefits.bereavement-allowance = Bereavement Allowance
 selectBenefits.carers-allowance = Carer’s Allowance
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -185,7 +185,7 @@ RemoveOtherSelectedOption.heading=A oes angen i chi roi gwybod i ni am unrhyw {0
 RemoveOtherSelectedOption.otherBenefits=buddiant trethadwy
 
 selectBenefits.blank=Dewiswch y buddiannau trethadwy eraill a gawsoch
-selectBenefits.other-taxable-benefit=buddiannau trethadwy arall
+selectBenefits.other-taxable-benefit=Buddiannau trethadwy arall
 
 selectCompanyBenefits.fuel-benefit=buddiant tanwydd
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,3 +1,5 @@
+service.name=Hawlio ad-daliad treth
+
 language-switcher.english=English
 language-switcher.english.hover=Use this account in English
 language-switcher.welsh=Cymraeg

--- a/test/controllers/AnyBenefitsControllerSpec.scala
+++ b/test/controllers/AnyBenefitsControllerSpec.scala
@@ -47,7 +47,7 @@ class AnyBenefitsControllerSpec extends ControllerSpecBase with MockitoSugar wit
     new AnyBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, mockTai, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), anyBenefits, messagesControllerComponents, formProvider, templateRenderer)
 
-  def viewAsString(form: Form[_] = form) = anyBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec).toString
+  def viewAsString(form: Form[_] = form) = anyBenefits(form, NormalMode, taxYear)(fakeRequest, messages, ec).toString
 
   "AnyBenefits Controller" must {
 

--- a/test/controllers/HowMuchBereavementAllowanceControllerSpec.scala
+++ b/test/controllers/HowMuchBereavementAllowanceControllerSpec.scala
@@ -47,7 +47,7 @@ class HowMuchBereavementAllowanceControllerSpec extends ControllerSpecBase with 
   private val taxYear = CustomTaxYear(2017)
   val form = new HowMuchBereavementAllowanceForm(frontendAppConfig)()
 
-  def viewAsString(form: Form[_] = form): String = howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec).toString
+  def viewAsString(form: Form[_] = form): String = howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages).toString
 
   "HowMuchBereavementAllowance Controller" must {
 

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -27,7 +27,7 @@ class IndexControllerSpec extends ControllerSpecBase with GuiceOneAppPerSuite {
 
   val selectTaxYear = fakeApplication.injector.instanceOf[selectTaxYear]
 
-  def viewAsString(form: Form[_] = SelectTaxYearForm()) = selectTaxYear(frontendAppConfig, form, NormalMode)(fakeRequest, messages, templateRenderer, ec).toString
+  def viewAsString(form: Form[_] = SelectTaxYearForm()) = selectTaxYear(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   "Index Controller" must {
     "return redirect for a GET and redirect to select tax year" in {

--- a/test/controllers/SelectBenefitsControllerSpec.scala
+++ b/test/controllers/SelectBenefitsControllerSpec.scala
@@ -43,7 +43,7 @@ class SelectBenefitsControllerSpec extends ControllerSpecBase with MockitoSugar 
     new SelectBenefitsController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), selectBenefits, messagesControllerComponents, templateRenderer)
 
-  def viewAsString(form: Form[_] = SelectBenefitsForm()) = selectBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec).toString
+  def viewAsString(form: Form[_] = SelectBenefitsForm()) = selectBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages).toString
 
   "SelectBenefits Controller" must {
 

--- a/test/controllers/SelectTaxYearControllerSpec.scala
+++ b/test/controllers/SelectTaxYearControllerSpec.scala
@@ -41,7 +41,7 @@ class SelectTaxYearControllerSpec extends ControllerSpecBase with GuiceOneAppPer
     new SelectTaxYearController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction(authConnector, frontendAppConfig),
       dataRetrievalAction, new DataRequiredActionImpl(messagesControllerComponents), selectTaxYear, messagesControllerComponents, templateRenderer)
 
-  def viewAsString(form: Form[_] = SelectTaxYearForm()) = selectTaxYear(frontendAppConfig, form, NormalMode)(fakeRequest, messages, templateRenderer, ec).toString
+  def viewAsString(form: Form[_] = SelectTaxYearForm()) = selectTaxYear(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   def radioButtonOptions: String = SelectTaxYear.options.head.value
 

--- a/test/controllers/SessionExpiredControllerSpec.scala
+++ b/test/controllers/SessionExpiredControllerSpec.scala
@@ -26,13 +26,13 @@ class SessionExpiredControllerSpec extends ControllerSpecBase with GuiceOneAppPe
 
   "SessionExpired Controller" must {
     "return 200 for a GET" in {
-      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents, templateRenderer, ec).onPageLoad()(fakeRequest)
+      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents).onPageLoad()(fakeRequest)
       status(result) mustBe OK
     }
 
     "return the correct view for a GET" in {
-      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents, templateRenderer, ec).onPageLoad()(fakeRequest)
-      contentAsString(result) mustBe sessionExpired(frontendAppConfig)(fakeRequest, messages, templateRenderer, ec).toString
+      val result = new SessionExpiredController(frontendAppConfig, sessionExpired, messagesControllerComponents).onPageLoad()(fakeRequest)
+      contentAsString(result) mustBe sessionExpired(frontendAppConfig)(fakeRequest, messages).toString
     }
   }
 }

--- a/test/views/AnyBenefitsViewSpec.scala
+++ b/test/views/AnyBenefitsViewSpec.scala
@@ -23,10 +23,10 @@ import models.SelectTaxYear.CustomTaxYear
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
-import views.behaviours.YesNoViewBehaviours
+import views.behaviours.{NewYesNoViewBehaviours, YesNoViewBehaviours}
 import views.html.anyBenefits
 
-class AnyBenefitsViewSpec extends YesNoViewBehaviours with GuiceOneAppPerSuite {
+class AnyBenefitsViewSpec extends NewYesNoViewBehaviours with GuiceOneAppPerSuite {
 
   private val messageKeyPrefix = "anyBenefits"
   private val listMessageKeyPrefix = "selectBenefits"
@@ -36,11 +36,11 @@ class AnyBenefitsViewSpec extends YesNoViewBehaviours with GuiceOneAppPerSuite {
   override val form = new BooleanForm()()
 
   def createView: () => HtmlFormat.Appendable = () =>
-    anyBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+    anyBenefits(form, NormalMode, taxYear)(fakeRequest, messages, ec)
 
   def createViewUsingForm: Form[_] =>
 		HtmlFormat.Appendable = (form: Form[_]) =>
-			anyBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+			anyBenefits(form, NormalMode, taxYear)(fakeRequest, messages, ec)
 
   "AnyBenefits view" must {
 

--- a/test/views/HowMuchBereavementAllowanceViewSpec.scala
+++ b/test/views/HowMuchBereavementAllowanceViewSpec.scala
@@ -23,10 +23,10 @@ import models.SelectTaxYear.CustomTaxYear
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
-import views.behaviours.StringViewBehaviours
+import views.behaviours.NewStringViewBehaviours
 import views.html.howMuchBereavementAllowance
 
-class HowMuchBereavementAllowanceViewSpec extends StringViewBehaviours with MockitoSugar with GuiceOneAppPerSuite {
+class HowMuchBereavementAllowanceViewSpec extends NewStringViewBehaviours with MockitoSugar with GuiceOneAppPerSuite {
 
   private val messageKeyPrefix = "howMuchBereavementAllowance"
   private val taxYear = CustomTaxYear(2017)
@@ -34,9 +34,9 @@ class HowMuchBereavementAllowanceViewSpec extends StringViewBehaviours with Mock
   override val form: Form[String] = new HowMuchBereavementAllowanceForm(frontendAppConfig)()
   val howMuchBereavementAllowance: howMuchBereavementAllowance = fakeApplication.injector.instanceOf[howMuchBereavementAllowance]
 
-  def createView = () => howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+  def createView = () => howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[String]) => howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+  def createViewUsingForm = (form: Form[String]) => howMuchBereavementAllowance(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages)
 
   "HowMuchBereavementAllowance view" must {
 

--- a/test/views/NewViewSpecBase.scala
+++ b/test/views/NewViewSpecBase.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.SpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.Html
+
+trait NewViewSpecBase extends SpecBase {
+
+  def asDocument(html: Html): Document = Jsoup.parse(html.toString())
+
+  def assertEqualsMessage(doc: Document, cssSelector: String, expectedMessageKey: String, args: Any*) =
+    assertEqualsValue(doc, cssSelector, messages(expectedMessageKey, args: _*))
+
+  def assertEqualsValue(doc: Document, cssSelector: String, expectedValue: String) = {
+    val elements = doc.select(cssSelector)
+
+    if (elements.isEmpty) throw new IllegalArgumentException(s"CSS Selector $cssSelector wasn't rendered.")
+
+    //<p> HTML elements are rendered out with a carriage return on some pages, so discount for comparison
+    assert(elements.first().html().replace("\n", "") == expectedValue)
+  }
+
+  def assertPageTitleEqualsMessage(doc: Document, expectedMessageKey: String, args: Any*) = {
+    val headers = doc.getElementsByTag("h1")
+    headers.first.text.replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args: _*).replaceAll("&nbsp;", " ")
+  }
+
+  def assertContainsText(doc: Document, text: String) = assert(doc.toString.contains(text), "\n\ntext " + text + " was not rendered on the page.\n")
+
+  def assertContainsMessages(doc: Document, expectedMessageKeys: String*) = {
+    for (key <- expectedMessageKeys) assertContainsText(doc, messages(key))
+  }
+
+  def assertRenderedById(doc: Document, id: String) = {
+    assert(doc.getElementById(id) != null, "\n\nElement " + id + " was not rendered on the page.\n")
+  }
+
+  def assertNotRenderedById(doc: Document, id: String) = {
+    assert(doc.getElementById(id) == null, "\n\nElement " + id + " was rendered on the page.\n")
+  }
+
+  def assertRenderedByCssSelector(doc: Document, cssSelector: String) = {
+    assert(!doc.select(cssSelector).isEmpty, "Element " + cssSelector + " was not rendered on the page.")
+  }
+
+  def assertNotRenderedByCssSelector(doc: Document, cssSelector: String) = {
+    assert(doc.select(cssSelector).isEmpty, "\n\nElement " + cssSelector + " was rendered on the page.\n")
+  }
+
+  def assertContainsLabel(doc: Document, forElement: String, expectedText: String, expectedHintTextLine1: Option[String] = None,
+                          expectedHintTextLine2: Option[String] = None) = {
+    val labels = doc.getElementsByAttributeValue("for", forElement)
+    assert(labels.size == 1, s"\n\nLabel for $forElement was not rendered on the page.")
+    val label = labels.first
+    assert(label.child(0).text == expectedText, s"\n\nLabel for $forElement was not $expectedText")
+
+    if (expectedHintTextLine1.isDefined) {
+      assert(label.getElementsByClass("form-hint").first.text == expectedHintTextLine1.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine1")
+    }
+
+    if (expectedHintTextLine2.isDefined) {
+      assert(label.getElementById("hint-line-2").text == expectedHintTextLine2.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine2")
+    }
+  }
+
+  def assertElementHasClass(doc: Document, id: String, expectedClass: String) = {
+    assert(doc.getElementById(id).hasClass(expectedClass), s"\n\nElement $id does not have class $expectedClass")
+  }
+
+  def assertContainsRadioButton(doc: Document, id: String, name: String, value: String, isChecked: Boolean) = {
+    assertRenderedById(doc, id)
+    val radio = doc.getElementById(id)
+    assert(radio.attr("name") == name, s"\n\nElement $id does not have name $name")
+    assert(radio.attr("value") == value, s"\n\nElement $id does not have value $value")
+    isChecked match {
+      case true => assert(radio.attr("checked") != null, s"\n\nElement $id is not checked")
+      case _ => assert(!radio.hasAttr("checked") && radio.attr("checked") != "checked", s"\n\nElement $id is checked")
+    }
+  }
+
+  def assertYesNoHint(doc: Document, expectedText: Option[String]) = {
+    val hint = doc.getElementsByClass("form-hint")
+    assert(hint != null , "\n\nhint was rendered on the page.\n")
+    assert(hint.text.contains(messages(expectedText.get)))
+  }
+
+}

--- a/test/views/SelectBenefitsViewSpec.scala
+++ b/test/views/SelectBenefitsViewSpec.scala
@@ -22,10 +22,10 @@ import models.{Benefits, NormalMode}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import play.twirl.api.Html
-import views.behaviours.{CheckboxViewBehaviours, ViewBehaviours}
+import views.behaviours.{NewCheckboxViewBehaviours, ViewBehaviours}
 import views.html.selectBenefits
 
-class SelectBenefitsViewSpec extends ViewBehaviours with CheckboxViewBehaviours[Benefits.Value] with GuiceOneAppPerSuite {
+class SelectBenefitsViewSpec extends ViewBehaviours with NewCheckboxViewBehaviours[Benefits.Value] with GuiceOneAppPerSuite {
 
   val messageKeyPrefix = "selectBenefits"
   val fieldKey = "value"
@@ -41,9 +41,9 @@ class SelectBenefitsViewSpec extends ViewBehaviours with CheckboxViewBehaviours[
   override def createView(): Html = createView(form)
 
   def createView(form: Form[Seq[Benefits.Value]]): Html =
-    selectBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+    selectBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[_]) => selectBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages, templateRenderer, ec)
+  def createViewUsingForm = (form: Form[_]) => selectBenefits(frontendAppConfig, form, NormalMode, taxYear)(fakeRequest, messages)
 
   "SelectBenefits view" must {
     behave like normalPage(createView, messageKeyPrefix, None)

--- a/test/views/SelectTaxYearViewSpec.scala
+++ b/test/views/SelectTaxYearViewSpec.scala
@@ -29,9 +29,9 @@ class SelectTaxYearViewSpec extends ViewBehaviours with GuiceOneAppPerSuite {
   private val messageKeyPrefix = "selectTaxYear"
   private val selectTaxYear: selectTaxYear = fakeApplication.injector.instanceOf[selectTaxYear]
 
-  def createView = () => selectTaxYear(frontendAppConfig, SelectTaxYearForm(), NormalMode)(fakeRequest, messages, templateRenderer, ec)
+  def createView = () => selectTaxYear(frontendAppConfig, SelectTaxYearForm(), NormalMode)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[_]) => selectTaxYear(frontendAppConfig, form, NormalMode)(fakeRequest, messages, templateRenderer, ec)
+  def createViewUsingForm = (form: Form[_]) => selectTaxYear(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
   def radioButtonOptions: Seq[RadioOption] = SelectTaxYear.options
 

--- a/test/views/SessionExpiredViewSpec.scala
+++ b/test/views/SessionExpiredViewSpec.scala
@@ -24,7 +24,7 @@ class SessionExpiredViewSpec extends ViewBehaviours with GuiceOneAppPerSuite {
 
   val sessionExpired: session_expired = fakeApplication.injector.instanceOf[session_expired]
 
-  def view = () => sessionExpired(frontendAppConfig)(fakeRequest, messages, templateRenderer, ec)
+  def view = () => sessionExpired(frontendAppConfig)(fakeRequest, messages)
 
   "Session Expired view" must {
 

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -93,7 +93,7 @@ trait ViewSpecBase extends SpecBase {
     assert(radio.attr("name") == name, s"\n\nElement $id does not have name $name")
     assert(radio.attr("value") == value, s"\n\nElement $id does not have value $value")
     isChecked match {
-      case true => assert(radio.attr("checked") == "checked", s"\n\nElement $id is not checked")
+      case true => assert(radio.attr("checked") != null, s"\n\nElement $id is not checked")
       case _ => assert(!radio.hasAttr("checked") && radio.attr("checked") != "checked", s"\n\nElement $id is checked")
     }
   }

--- a/test/views/behaviours/NewCheckboxViewBehaviours.scala
+++ b/test/views/behaviours/NewCheckboxViewBehaviours.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import play.api.data.{Form, FormError}
+import play.twirl.api.Html
+import views.ViewSpecBase
+
+trait NewCheckboxViewBehaviours[A] extends ViewSpecBase {
+
+  def form: Form[Seq[A]]
+  def createView(form: Form[Seq[A]]): Html
+  def createView(): Html = createView(form)
+  def values: Seq[(String, String)]
+
+  def fieldKey: String
+  def errorMessage: String
+  def messageKeyPrefix: String
+  lazy val error = FormError(fieldKey, errorMessage)
+
+  def fieldId(index: Int): String = {
+    index + 1 match {
+      case 1 => "value"
+      case i => form(fieldKey)(s"[$i]").id.replace("_", "-")
+    }
+  }
+
+  def checkboxPage(legend: Option[String] = None): Unit = {
+
+    "rendered" must {
+
+      "contain a legend for the question" in {
+        val doc = asDocument(createView())
+        val legends = doc.getElementsByTag("legend")
+        legends.size mustBe 1
+        legends.first.text mustBe legend.getOrElse(messages(s"$messageKeyPrefix.heading"))
+      }
+
+      "contain an input for the value" in {
+        val doc = asDocument(createView())
+        for { (value, i) <- values.zipWithIndex } yield {
+          assertRenderedById(doc, fieldId(i))
+        }
+      }
+
+      "contain a label for each input" in {
+        val doc = asDocument(createView())
+        for { ((label, value), i) <- values.zipWithIndex } yield {
+         val id = fieldId(i)
+          doc.select(s"label[for=$id]").text mustEqual messages(label).capitalize
+        }
+      }
+
+      "have no values checked when rendered with no form" in {
+        val doc = asDocument(createView())
+        for { (value, i) <- values.zipWithIndex } yield {
+          assert(!doc.getElementById(fieldId(i)).hasAttr("checked"))
+        }
+      }
+
+      values.zipWithIndex.foreach {
+        case (v, i) =>
+          s"has correct value checked when value `$v` is given" in {
+            val data: Map[String, String] = Map(
+              s"$fieldKey[$i]" -> v._2
+            )
+
+            val doc = asDocument(createView(form.bind(data)))
+
+            assert(doc.getElementById(fieldId(i)).hasAttr("checked"), s"${fieldId(i)} is not checked")
+
+            values.zipWithIndex.foreach {
+              case (value, j) =>
+                if (value != v) {
+                  assert(!doc.getElementById(fieldId(j)).hasAttr("checked"), s"${fieldId(j)} is checked")
+                }
+            }
+          }
+      }
+
+      "not render an error summary" in {
+        val doc = asDocument(createView())
+        assertNotRenderedById(doc, "error-summary-heading")
+      }
+
+
+			"show error in the title" in {
+				val doc = asDocument(createView(form.withError(error)))
+				doc.title.contains("Error: ") mustBe true
+			}
+    }
+
+    "rendered with an error" must {
+      "show an error summary" in {
+        val doc = asDocument(createView(form.withError(error)))
+        assertRenderedById(doc, "error-summary-title")
+      }
+
+      "show an error in the value field's label" in {
+        val doc = asDocument(createView(form.withError(error)))
+        val errorSpan = doc.getElementsByClass("govuk-error-message").first
+        errorSpan.text mustBe "Error: " + messages(errorMessage)
+      }
+    }
+  }
+}

--- a/test/views/behaviours/NewQuestionViewBehaviours.scala
+++ b/test/views/behaviours/NewQuestionViewBehaviours.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import play.api.data.{Form, FormError}
+import play.twirl.api.HtmlFormat
+
+trait NewQuestionViewBehaviours[A] extends NewViewBehaviours {
+
+  val errorKey = "value"
+  val errorMessage = "error.number"
+  val error = FormError(errorKey, errorMessage)
+
+  val form: Form[A]
+
+  def pageWithTextFields(createView: Form[A] => HtmlFormat.Appendable,
+                         messageKeyPrefix: String,
+                         expectedFormAction: String,
+                         fields: String*) = {
+
+    "behave like a question page" when {
+      "rendered" must {
+        for (field <- fields) {
+          s"contain an input for $field" in {
+            val doc = asDocument(createView(form))
+            assertRenderedById(doc, field)
+          }
+        }
+
+        "not render an error summary" in {
+          val doc = asDocument(createView(form))
+          assertNotRenderedById(doc, "error-summary-heading")
+        }
+
+
+        "show error in the title" in {
+          val doc = asDocument(createView(form.withError(error)))
+          doc.title.contains("Error: ") mustBe true
+        }
+      }
+
+      for (field <- fields) {
+        s"rendered with an error with field '$field'" must {
+          "show an error summary" in {
+            val doc = asDocument(createView(form.withError(FormError(field, "error"))))
+            assertRenderedById(doc, "error-summary-heading")
+          }
+
+          s"show an error in the label for field '$field'" in {
+            val doc = asDocument(createView(form.withError(FormError(field, "error"))))
+            val errorSpan = doc.getElementsByClass("error-notification").first
+            errorSpan.parent.attr("for") mustBe field
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/views/behaviours/NewStringViewBehaviours.scala
+++ b/test/views/behaviours/NewStringViewBehaviours.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import org.jsoup.nodes.Document
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+
+trait NewStringViewBehaviours extends QuestionViewBehaviours[String] {
+
+  val answer = "answer"
+
+  def stringPage(createView: Form[String] => HtmlFormat.Appendable,
+                 messageKeyPrefix: String,
+                 expectedFormAction: String,
+                 expectedHintKeyLine1: Option[String],
+                 expectedHintKeyLine2: Option[String],
+                 args: Any*) = {
+
+    "behave like a page with a string value field" when {
+      "rendered" must {
+
+        "contain a label for the value" in {
+          val doc = asDocument(createView(form))
+          val expectedHintTextLine1 = expectedHintKeyLine1 map (k => messages(k))
+          val expectedHintTextLine2 = expectedHintKeyLine2 map (k => messages(k))
+          assertContainsLabel(doc, "value", messages(s"$messageKeyPrefix.heading", args: _*), expectedHintTextLine1, expectedHintTextLine2)
+        }
+
+        "contain an input for the value" in {
+          val doc = asDocument(createView(form))
+          assertRenderedById(doc, "value")
+        }
+
+        "show error in the title" in {
+          val doc = asDocument(createView(form.withError(error)))
+          doc.title.contains("Error: ") mustBe true
+        }
+      }
+
+      "rendered with a valid form" must {
+        "include the form's value in the value input" in {
+          val doc = asDocument(createView(form.fill(answer)))
+          doc.getElementById("value").attr("value") mustBe answer
+        }
+      }
+
+      "rendered with an error" must {
+
+        "show an error summary" in {
+          val doc = asDocument(createView(form.withError(error)))
+          assertRenderedById(doc, "error-summary-title")
+        }
+
+        "show an error in the value field's label" in {
+          val doc = asDocument(createView(form.withError(error)))
+          val errorSpan = doc.getElementsByClass("govuk-error-message").first
+          errorSpan.text mustBe s"Error: ${messages(errorMessage)}"
+        }
+      }
+    }
+  }
+
+  override def assertContainsLabel(doc: Document, forElement: String, expectedText: String, expectedHintTextLine1: Option[String] = None,
+                                   expectedHintTextLine2: Option[String] = None) = {
+    val labels = doc.getElementsByAttributeValue("for", forElement)
+    assert(labels.size == 1, s"\n\nLabel for $forElement was not rendered on the page.")
+    val label = labels.first
+    assert(label.text == expectedText, s"\n\nLabel for $forElement was not $expectedText")
+
+    if (expectedHintTextLine1.isDefined) {
+      assert(label.getElementsByClass("form-hint").first.text == expectedHintTextLine1.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine1")
+    }
+
+    if (expectedHintTextLine2.isDefined) {
+      assert(label.getElementById("hint-line-2").text == expectedHintTextLine2.get,
+        s"\n\nLabel for $forElement did not contain hint text $expectedHintTextLine2")
+    }
+  }
+}

--- a/test/views/behaviours/NewViewBehaviours.scala
+++ b/test/views/behaviours/NewViewBehaviours.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import org.jsoup.Jsoup
+import play.twirl.api.HtmlFormat
+import views.{NewViewSpecBase, ViewSpecBase}
+
+trait NewViewBehaviours extends NewViewSpecBase {
+
+  def normalPage(view: () => HtmlFormat.Appendable,
+                 messageKeyPrefix: String,
+                 expectedGuidanceKeys: Option[String],
+                 args: Any*) = {
+
+    "behave like a normal page" when {
+      "rendered" must {
+        "display the correct browser title" in {
+          val doc = asDocument(view())
+          assertEqualsMessage(doc, "title", s"$messageKeyPrefix.title", args: _*)
+        }
+
+        "display the correct page title" in {
+          val doc = asDocument(view())
+          assertPageTitleEqualsMessage(doc, s"$messageKeyPrefix.heading", args: _*)
+        }
+
+        "display the correct guidance" in {
+          val doc = asDocument(view())
+          for (key <- expectedGuidanceKeys) assertContainsText(doc, messages(s"$messageKeyPrefix.$key"))
+        }
+      }
+    }
+  }
+
+  def pageWithBackLink(view: () => HtmlFormat.Appendable) = {
+
+    "behave like a page with a back link" must {
+      "have a back link" in {
+        val doc = asDocument(view())
+        assertRenderedById(doc, "back-link")
+      }
+    }
+  }
+
+  def pageWithSecondaryHeader(view: () => HtmlFormat.Appendable,
+                              heading: String) = {
+
+    "behave like a page with a secondary header" in {
+      Jsoup.parse(view().toString()).getElementsByClass("hmrc-caption-xl").text() must include(heading)
+    }
+  }
+
+  def pageWithList(view: () => HtmlFormat.Appendable,
+                   pageKey: String,
+                   bulletList: Seq[String],
+                   messageKeyPrefix: String) = {
+
+    "behave like a page with a list" must {
+      "have a list" in {
+        val doc = asDocument(view())
+        bulletList.foreach {
+          x => assertRenderedById(doc, s"bullet-$x")
+        }
+      }
+
+      "have correct values" in {
+        val doc = asDocument(view())
+        bulletList.foreach{
+          x => assertContainsMessages(doc, s"$messageKeyPrefix.$x")
+        }
+      }
+    }
+  }
+}

--- a/test/views/behaviours/NewYesNoViewBehaviours.scala
+++ b/test/views/behaviours/NewYesNoViewBehaviours.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import forms.BooleanForm
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+
+trait NewYesNoViewBehaviours extends NewQuestionViewBehaviours[Boolean] {
+
+  val formProvider = new BooleanForm()
+  val form = formProvider()
+
+  def yesNoPage(createView: (Form[Boolean]) => HtmlFormat.Appendable,
+                messageKeyPrefix: String,
+                expectedFormAction: String,
+                expectedHintTextKey: Option[String],
+                args: Any*) = {
+
+    "behave like a page with a Yes/No question" when {
+      "rendered" must {
+        "contain a legend for the question" in {
+          val doc = asDocument(createView(form))
+          val legends = doc.getElementsByTag("legend")
+          legends.size mustBe 1
+        }
+
+        "contain a heading" in {
+          val doc = asDocument(createView(form))
+          assertContainsText(doc, messages(s"$messageKeyPrefix.heading", args: _*))
+        }
+
+        if(expectedHintTextKey.isDefined){
+          "render a hint" in {
+            val doc = asDocument(createView(form))
+            assertYesNoHint(doc, expectedHintTextKey)
+          }
+        } else {
+          "not render a hint" in {
+            val doc = asDocument(createView(form))
+            assertNotRenderedByCssSelector(doc, ".form-hint")
+          }
+        }
+
+        "contain an input for the value" in {
+          val doc = asDocument(createView(form))
+          assertRenderedById(doc, "value")
+          assertRenderedById(doc, "value-2")
+        }
+
+        "have no values checked when rendered with no form" in {
+          val doc = asDocument(createView(form))
+          assert(!doc.getElementById("value").hasAttr("checked"))
+          assert(!doc.getElementById("value-2").hasAttr("checked"))
+        }
+
+        "not render an error summary" in {
+          val doc = asDocument(createView(form))
+          assertNotRenderedById(doc, "error-summary_header")
+        }
+
+				"show error in the title" in {
+					val doc = asDocument(createView(form.withError(error)))
+					doc.title.contains("Error: ") mustBe true
+				}
+      }
+
+      "rendered with a value of true" must {
+        behave like answeredYesNoPage(createView, true)
+      }
+
+      "rendered with a value of false" must {
+        behave like answeredYesNoPage(createView, false)
+      }
+
+      "rendered with an error" must {
+        "show an error summary" in {
+          val doc = asDocument(createView(form.withError(error)))
+          assertRenderedById(doc, "error-summary-title")
+        }
+
+        "show an error in the value field's label" in {
+          val doc = asDocument(createView(form.withError(error)))
+          val errorSpan = doc.getElementsByClass("govuk-error-message").first
+          errorSpan.text must include(messages(errorMessage))
+        }
+      }
+    }
+  }
+
+
+  def answeredYesNoPage(createView: (Form[Boolean]) => HtmlFormat.Appendable, answer: Boolean) = {
+
+    "have only the correct value checked" in {
+      val doc = asDocument(createView(form.fill(answer)))
+      assert(doc.getElementById("value").hasAttr("checked") == answer)
+      assert(doc.getElementById("value-2").hasAttr("checked") != answer)
+    }
+
+    "not render an error summary" in {
+      val doc = asDocument(createView(form.fill(answer)))
+      assertNotRenderedById(doc, "error-summary_header")
+    }
+  }
+}


### PR DESCRIPTION
# DL-5823 Support legend with caption for input_radio.scala.html

**New feature**

> If you are asking just one question per page as recommended, you can set the contents of the <legend> as the page heading - https://design-system.service.gov.uk/

Rework to the `input_radio.scala.html` CTR component to display a `caption` with the H1 that the `govukRadio` component does not support directly.

https://github.com/hmrc/play-frontend-govuk/blob/master/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/govukFieldset.scala.html#L26

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
