### PR TITLE
DL-5823 Support legend with caption for input_radio.scala.html

### DIFF
--- a/app/views/playComponents/heading.scala.html
+++ b/app/views/playComponents/heading.scala.html
@@ -1,31 +1,30 @@
 @*
- * Copyright 2021 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 
 @this()
 
 @(
-    heading: String,
-    headingSize: String = "heading-xlarge",
-    taxYear: Option[String] = None
+        heading: String,
+        headingSize: String = "heading-xlarge",
+        taxYear: Option[String] = None
 )(implicit messages: Messages)
 
-@secondaryHeaderText = @{
-    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
-}
+ @secondaryHeaderText = @{
+  if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
+ }
 
-<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
-<h1 class="govuk-fieldset__heading">@heading</h1>
+ <span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
 

--- a/app/views/playComponents/headingWithCaption.scala.html
+++ b/app/views/playComponents/headingWithCaption.scala.html
@@ -1,0 +1,31 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(
+    heading: String,
+    headingSize: String = "heading-xlarge",
+    taxYear: Option[String] = None
+)(implicit messages: Messages)
+
+@secondaryHeaderText = @{
+    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
+}
+
+<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
+<h1 class="govuk-fieldset__heading">@heading</h1>
+

--- a/app/views/selectTaxYear.scala.html
+++ b/app/views/selectTaxYear.scala.html
@@ -22,7 +22,7 @@
 
 @this(
         formWithCSRF: FormWithCSRF,
-        heading: playComponents.heading,
+        heading: playComponents.headingWithCaption,
         inputRadio: playComponents.input_radio,
         submitButton: playComponents.submit_button,
         errorSummary: playComponents.error_summary,


### PR DESCRIPTION
# DL-5823 Support legend with caption for input_radio.scala.html

**New feature**

> If you are asking just one question per page as recommended, you can set the contents of the <legend> as the page heading - https://design-system.service.gov.uk/

Rework to the `input_radio.scala.html` CTR component to display a `caption` with the H1 that the `govukRadio` component does not support directly.

https://github.com/hmrc/play-frontend-govuk/blob/master/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/govukFieldset.scala.html#L26

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
