### PR TITLE
DL-6208 - H1 Header spacing changes

### DIFF
--- a/app/forms/WhereToSendPaymentForm.scala
+++ b/app/forms/WhereToSendPaymentForm.scala
@@ -29,10 +29,10 @@ object WhereToSendPaymentForm extends FormErrorHelper {
   def apply(): Form[WhereToSendPayment] =
     Form(single("value" -> of(whereToSendPaymentFormatter)))
 
-  def options: Set[RadioOption] = WhereToSendPayment.values.map {
-    value =>
+  def options: Set[RadioOption] = WhereToSendPayment.values.zip(Seq("value", "value-2")).map {
+    case (value, govukId) =>
       RadioOption(
-        id = s"whereToSendPayment.$value",
+        id = govukId,
         value = value.toString,
         message = Message(s"whereToSendPayment.$value")
       )

--- a/app/models/SelectTaxYear.scala
+++ b/app/models/SelectTaxYear.scala
@@ -76,17 +76,17 @@ object SelectTaxYear extends Enumerable[SelectTaxYear] {
   }
 
   def options: Seq[RadioOption] = Seq(
-    taxYearRadioOption(TaxYear.current.back(1), CYMinus1),
-    taxYearRadioOption(TaxYear.current.back(2), CYMinus2),
-    taxYearRadioOption(TaxYear.current.back(3), CYMinus3),
-    taxYearRadioOption(TaxYear.current.back(4), CYMinus4)
+    taxYearRadioOption(TaxYear.current.back(1), CYMinus1, "value"),
+    taxYearRadioOption(TaxYear.current.back(2), CYMinus2, "value-2"),
+    taxYearRadioOption(TaxYear.current.back(3), CYMinus3, "value-3"),
+    taxYearRadioOption(TaxYear.current.back(4), CYMinus4, "value-4")
   )
 
-  private def taxYearRadioOption(taxYear: TaxYear, option: SelectTaxYear) =
+  private def taxYearRadioOption(taxYear: TaxYear, option: SelectTaxYear, id: String) =
     RadioOption(
-      keyPrefix   = "global",
-      option      = option.toString,
-      messageArgs = Seq(taxYear.startYear.toString.format(dateFormat), taxYear.finishYear.toString.format(dateFormat)): _*
+      id = id,
+      value = option.toString,
+      message = Message(s"global.$option", Seq(taxYear.startYear.toString.format(dateFormat), taxYear.finishYear.toString.format(dateFormat)): _*)
     )
 
   def values: Set[SelectTaxYear] = Set(

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -449,7 +449,7 @@ class CheckYourAnswersHelper(userAnswers: UserAnswers)(implicit messages: Messag
         case AnyAgentRef.Yes(agentRef) => "site.yes"
         case AnyAgentRef.No => "site.no"
       },
-			url = Some(routes.AnyAgentRefController.onPageLoad(CheckMode).url + "/#anyAgentRef-yes"),
+			url = Some(routes.AnyAgentRefController.onPageLoad(CheckMode).url + "/#anyAgentRef"),
 			changeLabel = messages("anyAgentRef.changeLabel", userAnswers.nomineeFullName.getOrElse("your nominee"))
 		)
   }
@@ -532,7 +532,7 @@ class CheckYourAnswersHelper(userAnswers: UserAnswers)(implicit messages: Messag
           case TelephoneOption.Yes(number) => "site.yes"
           case TelephoneOption.No => "site.no"
         },
-        url = Some(routes.TelephoneNumberController.onPageLoad(CheckMode).url + "/#anyTelephoneNumber-yes"),
+        url = Some(routes.TelephoneNumberController.onPageLoad(CheckMode).url + "/#anyTelephoneNumber"),
 				changeLabel = "telephoneNumber.changeLabel"
       )
   }

--- a/app/utils/CheckYourAnswersSections.scala
+++ b/app/utils/CheckYourAnswersSections.scala
@@ -150,7 +150,7 @@ class CheckYourAnswersSections(cyaHelper: CheckYourAnswersHelper, userAnswers: U
 		cyaHelper.anyTaxPaid(
 			"anyTaxableBankInterestOption.checkYourAnswersLabel",
 			userAnswers.anyTaxableBankInterest,
-			Some(routes.AnyTaxableBankInterestController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+			Some(routes.AnyTaxableBankInterestController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
 		),
 		cyaHelper.taxPaid(
 			"anyTaxableBankInterest.checkYourAnswersLabel",
@@ -162,7 +162,7 @@ class CheckYourAnswersSections(cyaHelper: CheckYourAnswersHelper, userAnswers: U
 		cyaHelper.anyTaxPaid(
 			"anyTaxableForeignIncomeOption.checkYourAnswersLabel",
 			userAnswers.anyTaxableForeignIncome,
-			Some(routes.AnyTaxableForeignIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+			Some(routes.AnyTaxableForeignIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
 		),
 		cyaHelper.taxPaid(
 			"anyTaxableForeignIncome.checkYourAnswersLabel",
@@ -174,7 +174,7 @@ class CheckYourAnswersSections(cyaHelper: CheckYourAnswersHelper, userAnswers: U
 		cyaHelper.anyTaxPaid(
 			"anyTaxableInvestmentsOption.checkYourAnswersLabel",
 			userAnswers.anyTaxableInvestments,
-			Some(routes.AnyTaxableInvestmentsController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+			Some(routes.AnyTaxableInvestmentsController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
 		),
 		cyaHelper.taxPaid(
 			"anyTaxableInvestments.checkYourAnswersLabel",
@@ -186,7 +186,7 @@ class CheckYourAnswersSections(cyaHelper: CheckYourAnswersHelper, userAnswers: U
     cyaHelper.anyTaxPaid(
       "anyTaxableRentalIncomeOption.checkYourAnswersLabel",
       userAnswers.anyTaxableRentalIncome,
-      Some(routes.AnyTaxableRentalIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+      Some(routes.AnyTaxableRentalIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
     ),
     cyaHelper.taxPaid(
       "anyTaxableRentalIncome.checkYourAnswersLabel",

--- a/app/views/anyAgentRef.scala.html
+++ b/app/views/anyAgentRef.scala.html
@@ -45,9 +45,10 @@
         @formWithCSRF(action = AnyAgentRefController.onSubmit(mode), 'autoComplete -> "off") {
 
             @errorSummary(form.errors)
-
+            @headingWithCaption(messages("anyAgentRef.heading", nomineeName), taxYear = Some(taxYear.asString))
             @inputYesNoWithTextExpander(
-                label = headingWithCaption(messages("anyAgentRef.heading", nomineeName), taxYear = Some(taxYear.asString)),
+                label = messages("anyAgentRef.heading", nomineeName),
+                labelClass = Some("govuk-visually-hidden"),
                 textLabel = messages("anyAgentRef.agentRefField"),
                 yesNoField = form("anyAgentRef"),
                 textField = form("agentRef"),

--- a/app/views/anyBenefits.scala.html
+++ b/app/views/anyBenefits.scala.html
@@ -19,7 +19,7 @@
 
 @this(
     layout: Layout,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     submitButton: playComponents.submit_button,
     errorSummary: playComponents.error_summary,
     formWithCSRF: FormWithCSRF,
@@ -47,10 +47,7 @@
 
         @errorSummary(form.errors)
 
-        @pageHeading(PageHeading(
-            text = messages("anyBenefits.heading"),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @pageHeading(heading = messages("anyBenefits.heading"), taxYear = Some(taxYear.asString))
 
         <p class="govuk-body" id="listHeading">@messages("anyBenefits.listHeading")</p>
 

--- a/app/views/anyCompanyBenefits.scala.html
+++ b/app/views/anyCompanyBenefits.scala.html
@@ -23,7 +23,7 @@
         layout: Layout,
         formWithCSRF: FormWithCSRF,
         errorSummary: playComponents.error_summary,
-        heading: hmrcPageHeading,
+        heading: playComponents.headingWithCaption,
         govukInput: GovukInput,
         submitButton: playComponents.submit_button,
         inputYesOrNo: playComponents.input_yes_no
@@ -49,10 +49,8 @@
 
             @errorSummary(form.errors)
 
-            @heading(PageHeading(
-                text = messages("anyCompanyBenefits.heading"),
-                section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-            ))
+            @heading(heading = messages("anyCompanyBenefits.heading"),
+                taxYear = Some(taxYear.asString))
 
             <p class="govuk-body" id="listHeading">@messages("anyCompanyBenefits.listHeading")</p>
 
@@ -63,6 +61,7 @@
             )
 
             @inputYesOrNo(
+                isPageHeading = false,
                 label = messages("anyCompanyBenefits.heading"),
                 labelClass = Some("govuk-visually-hidden"),
                 field = form("value")

--- a/app/views/anyOtherBenefits.scala.html
+++ b/app/views/anyOtherBenefits.scala.html
@@ -22,7 +22,7 @@
     formWithCSRF: FormWithCSRF,
     layout: Layout,
     errorSummary: playComponents.error_summary,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     inputYesNo: playComponents.input_yes_no,
     govukTable : GovukTable,
     submitButton: playComponents.submit_button,
@@ -54,10 +54,8 @@
 
             @errorSummary(form.errors)
 
-            @pageHeading(PageHeading(
-                text = messages("anyOtherBenefits.heading"),
-                section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-            ))
+            @pageHeading(heading = messages("anyOtherBenefits.heading"),
+                taxYear = Some(taxYear.asString))
 
             @otherSummary(
                 answers = otherBenefits.rows

--- a/app/views/anyOtherCompanyBenefits.scala.html
+++ b/app/views/anyOtherCompanyBenefits.scala.html
@@ -25,7 +25,7 @@
     formWithCSRF: FormWithCSRF,
     layout: Layout,
     errorSummary: playComponents.error_summary,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     otherSummary: playComponents.other_summary,
     inputYesNo: playComponents.input_yes_no,
     submitButton: playComponents.submit_button
@@ -55,10 +55,8 @@
 
             @errorSummary(form.errors)
 
-            @pageHeading(PageHeading(
-                text = messages("anyOtherCompanyBenefits.heading"),
-                section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-            ))
+            @pageHeading(heading = messages("anyOtherCompanyBenefits.heading"),
+                taxYear = Some(taxYear.asString))
 
             @otherSummary(
                 answers = otherCompanyBenefits.rows

--- a/app/views/anyOtherTaxableIncome.scala.html
+++ b/app/views/anyOtherTaxableIncome.scala.html
@@ -27,7 +27,7 @@
     heading: playComponents.heading,
     submitButton: playComponents.submit_button,
     errorSummary: playComponents.error_summary,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     addListSummary: playComponents.add_list_summary,
     backLink: playComponents.back_link,
     inputYesNo: playComponents.input_yes_no,
@@ -65,10 +65,8 @@
 
             @errorSummary(form.errors)
 
-            @pageHeading(PageHeading(
-                text = messages("anyOtherTaxableIncome.heading"),
-                section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-            ))
+            @pageHeading(heading = messages("anyOtherTaxableIncome.heading"),
+                taxYear = Some(taxYear.asString))
 
             @addListSummary(
                 complete, incomplete, mode

--- a/app/views/anyTaxableBankInterest.scala.html
+++ b/app/views/anyTaxableBankInterest.scala.html
@@ -43,10 +43,11 @@
     @formWithCSRF(action = AnyTaxableBankInterestController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("anyTaxableBankInterest.heading"), taxYear = Some(taxYear.asString))
         @inputYesNoWithTextExpander(
             hint = None,
-            label = headingWithCaption(messages("anyTaxableBankInterest.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("anyTaxableBankInterest.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             textLabel = messages("anyTaxableBankInterest.anyTaxPaidAmountField"),
             currency = true,
             autoComplete = true,

--- a/app/views/anyTaxableForeignIncome.scala.html
+++ b/app/views/anyTaxableForeignIncome.scala.html
@@ -45,10 +45,11 @@
     @formWithCSRF(action = AnyTaxableForeignIncomeController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("anyTaxableForeignIncome.heading"), taxYear = Some(taxYear.asString))
         @inputYesNoWithTextExpander(
             hint = None,
-            label = headingWithCaption(messages("anyTaxableForeignIncome.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("anyTaxableForeignIncome.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             textLabel = messages("anyTaxableForeignIncome.anyTaxPaidAmountField"),
             currency = true,
             autoComplete = true,

--- a/app/views/anyTaxableIncome.scala.html
+++ b/app/views/anyTaxableIncome.scala.html
@@ -22,7 +22,7 @@
         layout: Layout,
         formWithCSRF: FormWithCSRF,
         errorSummary: playComponents.error_summary,
-        heading: hmrcPageHeading,
+        heading: playComponents.headingWithCaption,
         govukInput: GovukInput,
         submitButton: playComponents.submit_button,
         inputYesOrNo: playComponents.input_yes_no
@@ -48,10 +48,8 @@
 
         @errorSummary(form.errors)
 
-        @heading(PageHeading(
-            text = messages("anyTaxableIncome.heading"),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @heading(messages("anyTaxableIncome.heading"),
+            taxYear = Some(taxYear.asString))
 
         <p class="govuk-body" id="listHeading">@messages("anyTaxableIncome.listHeading")</p>
 

--- a/app/views/anyTaxableInvestments.scala.html
+++ b/app/views/anyTaxableInvestments.scala.html
@@ -46,9 +46,10 @@
     @formWithCSRF(action = AnyTaxableInvestmentsController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("anyTaxableInvestments.heading"), taxYear = Some(taxYear.asString))
         @inputYesNoWithTextExpander(
-            label = headingWithCaption(messages("anyTaxableInvestments.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("anyTaxableInvestments.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             textLabel = messages("anyTaxableInvestments.anyTaxPaidAmountField"),
             hint = None,
             currency = true,

--- a/app/views/anyTaxableOtherIncome.scala.html
+++ b/app/views/anyTaxableOtherIncome.scala.html
@@ -48,10 +48,11 @@
     @formWithCSRF(action = AnyTaxableOtherIncomeController.onSubmit(mode, index), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("anyTaxableOtherIncome.heading", incomeName), taxYear = Some(taxYear.asString))
         @inputYesNoWithTextExpander(
             hint = None,
-            label = headingWithCaption(messages("anyTaxableOtherIncome.heading", incomeName), taxYear = Some(taxYear.asString)),
+            label = messages("anyTaxableOtherIncome.heading", incomeName),
+            labelClass = Some("govuk-visually-hidden"),
             textLabel = messages("anyTaxableOtherIncome.anyTaxPaidAmountField", incomeName),
             currency = true,
             autoComplete = true,

--- a/app/views/anyTaxableRentalIncome.scala.html
+++ b/app/views/anyTaxableRentalIncome.scala.html
@@ -44,10 +44,11 @@
     @formWithCSRF(action = AnyTaxableRentalIncomeController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("anyTaxableRentalIncome.heading"), taxYear = Some(taxYear.asString))
         @inputYesNoWithTextExpander(
             hint = None,
-            label = headingWithCaption(messages("anyTaxableRentalIncome.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("anyTaxableRentalIncome.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             textLabel = messages("anyTaxableRentalIncome.anyTaxPaidAmountField"),
             currency = true,
             autoComplete = true,

--- a/app/views/deleteOther.scala.html
+++ b/app/views/deleteOther.scala.html
@@ -24,7 +24,7 @@
     layout: Layout,
     formWithCSRF: FormWithCSRF,
     errorSummary: playComponents.error_summary,
-    heading: hmrcPageHeading,
+    heading: playComponents.headingWithCaption,
     inputYesOrNo: playComponents.input_yes_no,
     submitButton: playComponents.submit_button
 
@@ -54,10 +54,8 @@
 
         @errorSummary(form.errors)
 
-        @heading(PageHeading(
-            text = messages("deleteOther.heading", itemName),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @heading(messages("deleteOther.heading", itemName),
+            taxYear = Some(taxYear.asString))
 
         @inputYesOrNo(
             isPageHeading = false,

--- a/app/views/detailsOfEmploymentOrPension.scala.html
+++ b/app/views/detailsOfEmploymentOrPension.scala.html
@@ -49,11 +49,11 @@
     @formWithCSRF(action = DetailsOfEmploymentOrPensionController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("detailsOfEmploymentOrPension.heading"), taxYear = Some(taxYear.asString))
         @inputTextArea(
             InputViewModel("value", form),
-            label = headingWithCaption(messages("detailsOfEmploymentOrPension.heading"), taxYear = Some(taxYear.asString)),
-            labelClass = None,
+            label = messages("detailsOfEmploymentOrPension.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             hint = Some(messages("detailsOfEmploymentOrPension.hintText")),
             charLimit = Some(characterLimit),
             field = form("value")

--- a/app/views/employmentDetails.scala.html
+++ b/app/views/employmentDetails.scala.html
@@ -19,7 +19,7 @@
 
 @this(
     layout: Layout,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     submitButton: playComponents.submit_button,
     errorSummary: playComponents.error_summary,
     formWithCSRF: FormWithCSRF,
@@ -47,11 +47,7 @@
 
 @errorSummary(form.errors)
 
-        @pageHeading(PageHeading(
-            text = messages("employmentDetails.heading"),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
-
+        @pageHeading(heading = messages("employmentDetails.heading"), taxYear = Some(taxYear.asString))
         @govukTable(Table(
             head = Some(Seq(
                 HeadCell(content = Text(Messages("employmentDetails.employer"))),

--- a/app/views/enterPayeReference.scala.html
+++ b/app/views/enterPayeReference.scala.html
@@ -50,9 +50,10 @@
     @formWithCSRF(action = EnterPayeReferenceController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("enterPayeReference.heading"), taxYear = Some(taxYear.asString))
         @inputText(
-            label = headingWithCaption(messages("enterPayeReference.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("enterPayeReference.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             hintLine1 = Some(messages("enterPayeReference.hint")),
             field = form("value")
         )

--- a/app/views/howMuchBankInterest.scala.html
+++ b/app/views/howMuchBankInterest.scala.html
@@ -51,8 +51,11 @@
 
         @errorSummary(form.errors)
 
+        @headingWithCaption(messages("howMuchBankInterest.heading"), taxYear = Some(taxYear.asString))
+
         @inputText(
-        label = headingWithCaption(messages("howMuchBankInterest.heading"), taxYear = Some(taxYear.asString)),
+        label = messages("howMuchBankInterest.heading"),
+        labelClass = Some("govuk-visually-hidden"),
         currency = true,
         field = form("value")
         )

--- a/app/views/howMuchBereavementAllowance.scala.html
+++ b/app/views/howMuchBereavementAllowance.scala.html
@@ -22,7 +22,7 @@
         layout: Layout,
         formWithCSRF: FormWithCSRF,
         errorSummary: playComponents.error_summary,
-        heading: playComponents.heading,
+        caption: playComponents.caption,
         govukInput : GovukInput,
         submitButton: playComponents.submit_button
 )
@@ -47,7 +47,7 @@
     @formWithCSRF(action = HowMuchBereavementAllowanceController.onSubmit(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
-        @heading(messages("howMuchBereavementAllowance.heading"), taxYear = Some(taxYear.asString))
+        @caption(taxYear = Some(taxYear.asString))
 
         @govukInput(
             Input(

--- a/app/views/howMuchCarBenefits.scala.html
+++ b/app/views/howMuchCarBenefits.scala.html
@@ -51,8 +51,11 @@
 
         @errorSummary(form.errors)
 
+        @headingWithCaption(messages("howMuchCarBenefits.heading"), taxYear = Some(taxYear.asString))
+
         @inputText(
-        label = headingWithCaption(messages("howMuchCarBenefits.heading"), taxYear = Some(taxYear.asString)),
+        label = messages("howMuchCarBenefits.heading"),
+        labelClass = Some("govuk-visually-hidden"),
         currency = true,
         field = form("value")
         )

--- a/app/views/howMuchCarersAllowance.scala.html
+++ b/app/views/howMuchCarersAllowance.scala.html
@@ -46,9 +46,10 @@
     @formWithCSRF(action = HowMuchCarersAllowanceController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("howMuchCarersAllowance.heading"), taxYear = Some(taxYear.asString))
         @inputText(
-            label = headingWithCaption(messages("howMuchCarersAllowance.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("howMuchCarersAllowance.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/views/howMuchEmploymentAndSupportAllowance.scala.html
+++ b/app/views/howMuchEmploymentAndSupportAllowance.scala.html
@@ -52,8 +52,11 @@
 
         @errorSummary(form.errors)
 
+        @headingWithCaption(messages("howMuchEmploymentAndSupportAllowance.heading"), taxYear = Some(taxYear.asString))
+
         @input_text(
-            label = headingWithCaption(messages("howMuchEmploymentAndSupportAllowance.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("howMuchEmploymentAndSupportAllowance.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/views/howMuchForeignIncome.scala.html
+++ b/app/views/howMuchForeignIncome.scala.html
@@ -49,8 +49,11 @@
 
         @errorSummary(form.errors)
 
+        @headingWithCaption(messages("howMuchForeignIncome.heading"), taxYear = Some(taxYear.asString))
+
         @inputText(
-            label = headingWithCaption(messages("howMuchForeignIncome.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("howMuchForeignIncome.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/views/howMuchFuelBenefit.scala.html
+++ b/app/views/howMuchFuelBenefit.scala.html
@@ -50,9 +50,10 @@
         @formWithCSRF(action = HowMuchFuelBenefitController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("howMuchFuelBenefit.heading"), taxYear = Some(taxYear.asString))
         @inputText(
-        label = headingWithCaption(messages("howMuchFuelBenefit.heading"), taxYear = Some(taxYear.asString)),
+        label = messages("howMuchFuelBenefit.heading"),
+        labelClass = Some("govuk-visually-hidden"),
         currency = true,
         field = form("value")
         )

--- a/app/views/howMuchIncapacityBenefit.scala.html
+++ b/app/views/howMuchIncapacityBenefit.scala.html
@@ -51,9 +51,11 @@
 
             @errorSummary(form.errors)
 
+            @headingWithCaption(messages("howMuchIncapacityBenefit.heading"), taxYear = Some(taxYear.asString))
 
             @inputText(
-                label = headingWithCaption(messages("howMuchIncapacityBenefit.heading"), taxYear = Some(taxYear.asString)),
+                label = messages("howMuchIncapacityBenefit.heading"),
+                labelClass = Some("govuk-visually-hidden"),
                 currency = true,
                 field = form("value")
             )

--- a/app/views/howMuchInvestmentOrDividend.scala.html
+++ b/app/views/howMuchInvestmentOrDividend.scala.html
@@ -22,7 +22,7 @@
         formWithCSRF: FormWithCSRF,
         layout: Layout,
         errorSummary: playComponents.error_summary,
-        heading: playComponents.heading,
+        caption: playComponents.caption,
         govukInput: GovukInput,
         submitButton: playComponents.submit_button
 )
@@ -48,7 +48,7 @@
 
             @errorSummary(form.errors)
 
-            @heading(messages("howMuchInvestmentOrDividend.heading"), taxYear = Some(taxYear.asString))
+            @caption(taxYear = Some(taxYear.asString))
 
             @govukInput(
 

--- a/app/views/howMuchJobseekersAllowance.scala.html
+++ b/app/views/howMuchJobseekersAllowance.scala.html
@@ -21,7 +21,7 @@
         formWithCSRF: FormWithCSRF,
         layout: Layout,
         errorSummary: playComponents.error_summary,
-        heading: playComponents.heading,
+        caption: playComponents.caption,
         govukInput: GovukInput,
         submitButton: playComponents.submit_button
 )
@@ -46,7 +46,7 @@
 
             @errorSummary(form.errors)
 
-            @heading(messages("howMuchJobseekersAllowance.heading"), taxYear = Some(taxYear.asString))
+            @caption(taxYear = Some(taxYear.asString))
 
             @govukInput(
 

--- a/app/views/howMuchMedicalBenefits.scala.html
+++ b/app/views/howMuchMedicalBenefits.scala.html
@@ -47,8 +47,11 @@ pageTitle = title
 
         @errorSummary(form.errors)
 
+        @headingWithCaption(messages("howMuchMedicalBenefits.heading"), taxYear = Some(taxYear.asString))
+
         @inputText(
-            label = headingWithCaption(messages("howMuchMedicalBenefits.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("howMuchMedicalBenefits.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/views/howMuchRentalIncome.scala.html
+++ b/app/views/howMuchRentalIncome.scala.html
@@ -46,9 +46,10 @@
         @formWithCSRF(action = HowMuchRentalIncomeController.onSubmit(mode), 'autoComplete -> "off") {
 
             @errorSummary(form.errors)
-
+            @headingWithCaption(messages("howMuchRentalIncome.heading"), taxYear = Some(taxYear.asString))
             @inputText(
-                label = headingWithCaption(messages("howMuchRentalIncome.heading"), taxYear = Some(taxYear.asString)),
+                label = messages("howMuchRentalIncome.heading"),
+                labelClass = Some("govuk-visually-hidden"),
                 currency = true,
                 field = form("value")
             )

--- a/app/views/howMuchStatePension.scala.html
+++ b/app/views/howMuchStatePension.scala.html
@@ -49,8 +49,11 @@
 
         @errorSummary(form.errors)
 
+        @headingWithCaption(messages("howMuchStatePension.heading"), taxYear = Some(taxYear.asString))
+
         @input_text(
-            label = headingWithCaption(messages("howMuchStatePension.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("howMuchStatePension.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/views/isPaymentAddressInTheUK.scala.html
+++ b/app/views/isPaymentAddressInTheUK.scala.html
@@ -23,7 +23,7 @@
     formWithCSRF: FormWithCSRF,
     layout: Layout,
     errorSummary: playComponents.error_summary,
-    heading: playComponents.heading,
+    heading: playComponents.headingWithCaption,
     inputYesNo: playComponents.input_yes_no,
     submitButton: playComponents.submit_button
 )
@@ -53,6 +53,7 @@
 
         @inputYesNo(
             label = messages("isPaymentAddressInTheUK.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             field = form("value")
         )
 

--- a/app/views/nomineeFullName.scala.html
+++ b/app/views/nomineeFullName.scala.html
@@ -48,10 +48,10 @@
         @formWithCSRF(action = NomineeFullNameController.onSubmit(mode), 'autoComplete -> "off") {
 
             @errorSummary(form.errors)
-
+            @headingWithCaption(messages("nomineeFullName.heading"), taxYear = Some(taxYear.asString))
             @inputText(
-                label = headingWithCaption(messages("nomineeFullName.heading"), taxYear = Some(taxYear.asString)),
-                labelClass = Some("visually-hidden"),
+                label = messages("nomineeFullName.heading"),
+                labelClass = Some("govuk-visually-hidden"),
                 field = form("value")
             )
 

--- a/app/views/otherBenefit.scala.html
+++ b/app/views/otherBenefit.scala.html
@@ -25,7 +25,7 @@
     headingWithCaption: playComponents.headingWithCaption,
     errorSummary: playComponents.error_summary,
     inputText: playComponents.input_text,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     submitButton: playComponents.submit_button
 )
 
@@ -53,20 +53,18 @@
 
         @errorSummary(form.errors)
 
-        @pageHeading(PageHeading(
-            text = messages("otherBenefit.heading", index.id + 1),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @pageHeading(heading = messages("otherBenefit.heading", index.id + 1),
+            taxYear = Some(taxYear.asString))
 
         @inputText(
-            label = Html(messages("otherBenefit.name")),
+            label = messages("otherBenefit.name"),
             isPageHeading = false,
             largeText = false,
             field = form("name")
         )
 
         @inputText(
-            label = Html(messages("otherBenefit.amount")),
+            label = messages("otherBenefit.amount"),
             currency = true,
             isPageHeading = false,
             largeText = false,

--- a/app/views/otherCompanyBenefit.scala.html
+++ b/app/views/otherCompanyBenefit.scala.html
@@ -25,7 +25,7 @@
     headingWithCaption: playComponents.headingWithCaption,
     errorSummary: playComponents.error_summary,
     inputText: playComponents.input_text,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     submitButton: playComponents.submit_button
 )
 
@@ -54,20 +54,18 @@
 
         @errorSummary(form.errors)
 
-        @pageHeading(PageHeading(
-            text = messages("otherCompanyBenefit.heading", index.id + 1),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString)))
-        )
+        @pageHeading(messages("otherCompanyBenefit.heading", index.id + 1),
+            taxYear = Some(taxYear.asString))
 
         @inputText(
-            label = Html(messages("otherCompanyBenefit.name")),
+            label = messages("otherCompanyBenefit.name"),
             isPageHeading = false,
             largeText = false,
             field = form("name")
         )
 
         @inputText(
-            label = Html(messages("otherCompanyBenefit.amount")),
+            label = messages("otherCompanyBenefit.amount"),
             currency = true,
             isPageHeading = false,
             largeText = false,

--- a/app/views/otherTaxableIncome.scala.html
+++ b/app/views/otherTaxableIncome.scala.html
@@ -23,7 +23,7 @@
     layout: Layout,
     formWithCSRF: FormWithCSRF,
     errorSummary: playComponents.error_summary,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     inputText: playComponents.input_text,
     submitButton: playComponents.submit_button
 )
@@ -51,20 +51,18 @@
 
         @errorSummary(form.errors)
 
-        @pageHeading(PageHeading(
-            text = messages("otherTaxableIncome.heading", index.id + 1),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @pageHeading(messages("otherTaxableIncome.heading", index.id + 1),
+            taxYear = Some(taxYear.asString))
 
         @inputText(
-            label = Html(messages("otherTaxableIncome.name")),
+            label = messages("otherTaxableIncome.name"),
             isPageHeading = false,
             largeText = false,
             field = form("name")
         )
 
         @inputText(
-            label = Html(messages("otherTaxableIncome.amount")),
+            label = messages("otherTaxableIncome.amount"),
             currency = true,
             isPageHeading = false,
             largeText = false,

--- a/app/views/paymentAddressCorrect.scala.html
+++ b/app/views/paymentAddressCorrect.scala.html
@@ -21,7 +21,7 @@
     layout: Layout,
     formWithCSRF: FormWithCSRF,
     errorSummary: playComponents.error_summary,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
     inputYesNo: playComponents.input_yes_no,
     submitButton: playComponents.submit_button
 )
@@ -49,10 +49,8 @@
 
         @errorSummary(form.errors)
 
-        @pageHeading(PageHeading(
-            text = messages("paymentAddressCorrect.heading"),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @pageHeading(messages("paymentAddressCorrect.heading"),
+            taxYear = Some(taxYear.asString))
 
         <ul class="govuk-list govuk-list" id="usersAddress">
             @if(address.line1.exists(_.trim.nonEmpty)) {<li>@address.line1</li>}

--- a/app/views/paymentInternationalAddress.scala.html
+++ b/app/views/paymentInternationalAddress.scala.html
@@ -22,7 +22,7 @@
     layout: Layout,
     formWithCSRF: FormWithCSRF,
     errorSummary: playComponents.error_summary,
-    heading: hmrcPageHeading,
+    heading: playComponents.headingWithCaption,
     inputText: playComponents.input_text,
     submitButton: playComponents.submit_button
 )
@@ -50,48 +50,46 @@
 
             @errorSummary(form.errors)
 
-            @heading(PageHeading(
-                text = messages("paymentInternationalAddress.heading"),
-                section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-            ))
+            @heading(messages("paymentInternationalAddress.heading"),
+                taxYear = Some(taxYear.asString))
 
             @inputText(
-                label = Html(messages("global.addressLine1")),
+                label = messages("global.addressLine1"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine1")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine2")),
+                label = messages("global.addressLine2"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine2")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine3")),
+                label = messages("global.addressLine3"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine3")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine4")),
+                label = messages("global.addressLine4"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine4")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine5")),
+                label = messages("global.addressLine5"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine5")
             )
 
             @inputText(
-                label = Html(messages("global.country")),
+                label = messages("global.country"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("country")

--- a/app/views/paymentUKAddress.scala.html
+++ b/app/views/paymentUKAddress.scala.html
@@ -26,7 +26,7 @@
     errorSummary: playComponents.error_summary,
     inputText: playComponents.input_text,
     submitButton: playComponents.submit_button,
-    pageHeading: hmrcPageHeading,
+    pageHeading: playComponents.headingWithCaption,
 )
 
 @(
@@ -51,48 +51,46 @@
 
             @errorSummary(form.errors)
 
-            @pageHeading(PageHeading(
-                text = messages("paymentUKAddress.heading"),
-                section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-            ))
+            @pageHeading(messages("paymentUKAddress.heading"),
+                taxYear = Some(taxYear.asString))
 
             @inputText(
-                label = Html(messages("global.addressLine1")),
+                label = messages("global.addressLine1"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine1")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine2")),
+                label = messages("global.addressLine2"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine2")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine3")),
+                label = messages("global.addressLine3"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine3")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine4")),
+                label = messages("global.addressLine4"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine4")
             )
 
             @inputText(
-                label = Html(messages("global.addressLine5")),
+                label = messages("global.addressLine5"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("addressLine5")
             )
 
             @inputText(
-                label = Html(messages("global.postcode")),
+                label = messages("global.postcode"),
                 isPageHeading = false,
                 largeText = false,
                 field = form("postcode")

--- a/app/views/playComponents/caption.scala.html
+++ b/app/views/playComponents/caption.scala.html
@@ -14,27 +14,14 @@
 * limitations under the License.
 *@
 
-@this(
-        layout: Layout,
-        pageHeading: playComponents.heading
-)
+@this()
 
 @(
-        pageTitle: String,
-        heading: String,
-        errorMessages: Seq[String],
-)(
-        implicit request: Request[_],
-        messages: Messages
-)
+    taxYear: Option[String] = None
+)(implicit messages: Messages)
 
-@layout(
-    pageTitle = pageTitle
-) {
-
-    @pageHeading(messages(heading))
-
-    @for(errorMessage <- errorMessages) {
-        <p class="govuk-body">@messages(errorMessage)</p>
-    }
+@secondaryHeaderText = @{
+    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
 }
+
+<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>

--- a/app/views/playComponents/heading.scala.html
+++ b/app/views/playComponents/heading.scala.html
@@ -19,12 +19,6 @@
 @(
         heading: String,
         headingSize: String = "heading-xlarge",
-        taxYear: Option[String] = None
 )(implicit messages: Messages)
 
- @secondaryHeaderText = @{
-  if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
- }
-
- <span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
-
+<h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-4">@heading</h1>

--- a/app/views/playComponents/headingWithCaption.scala.html
+++ b/app/views/playComponents/headingWithCaption.scala.html
@@ -14,7 +14,10 @@
  * limitations under the License.
  *@
 
-@this()
+@this(
+    caption: playComponents.caption,
+    headingComponent: playComponents.heading
+)
 
 @(
     heading: String,
@@ -22,10 +25,5 @@
     taxYear: Option[String] = None
 )(implicit messages: Messages)
 
-@secondaryHeaderText = @{
-    if (taxYear.isDefined) messages("site.service_name.with_tax_year", taxYear.get) else messages("site.service_name")
-}
-
-<span class="govuk-caption-xl heading-secondary">@secondaryHeaderText</span>
-<h1 class="govuk-fieldset__heading">@heading</h1>
-
+@caption(taxYear)
+@headingComponent(heading)

--- a/app/views/playComponents/input_check_box.scala.html
+++ b/app/views/playComponents/input_check_box.scala.html
@@ -22,6 +22,7 @@
 @(
 viewModel: InputViewModelBase,
 legend: String,
+isPageHeading: Boolean = true,
 legendClass: Option[String] = None,
 hint: Option[String] = None,
 trackGa: Boolean = false,
@@ -33,8 +34,8 @@ field: Field)(implicit messages: Messages)
                 fieldset = Some(Fieldset(
                   legend = Some(Legend(
                     content = Text(legend),
-                    classes = "govuk-fieldset__legend--xl",
-                    isPageHeading = true
+                    classes = s"""govuk-fieldset__legend--xl ${legendClass.getOrElse("")}""",
+                    isPageHeading = isPageHeading
                   ))
                 )),
         items = inputs,

--- a/app/views/playComponents/input_text.scala.html
+++ b/app/views/playComponents/input_text.scala.html
@@ -17,14 +17,14 @@
 @this(govukInput : GovukInput)
 
 @(
-        label: Html,
+        label: String,
         hintLine1: Option[String] = None,
         hintLine2: Option[String] = None,
         labelClass: Option[String] = None,
         currency: Boolean = false,
         inputType: String = "text",
         autoComplete: Option[String] = None,
-        isPageHeading: Boolean = true,
+        isPageHeading: Boolean = false,
         largeText: Boolean = true,
         field: Field
 )(implicit messages: Messages)
@@ -37,9 +37,9 @@
 
 @govukInput(Input(
     label = Label(
-        isPageHeading = false,
-        classes = if(largeText) "govuk-label--xl" else "govuk-label--m",
-        content = HtmlContent(label)
+        isPageHeading = isPageHeading,
+        classes = s"""${if(largeText) "govuk-label--xl" else "govuk-label--m"} ${labelClass.getOrElse("")}""",
+        content = Text(label)
     ),
     hint = hint.map(hintString => Hint(content = Text(hintString))),
     classes = "govuk-input--width-10",

--- a/app/views/playComponents/input_textarea.scala.html
+++ b/app/views/playComponents/input_textarea.scala.html
@@ -22,7 +22,7 @@
 
 @(
     viewModel: InputViewModelBase,
-    label: Html,
+    label: String,
     secondaryLabel: Option[String] = None,
     inputClass: Option[String] = None,
     hint: Option[String] = None,
@@ -35,8 +35,8 @@
 @govukTextarea(Textarea(
     label = Label(
         isPageHeading = false,
-        classes = "govuk-label--xl",
-        content = HtmlContent(label)
+        classes = s"""govuk-label--xl ${labelClass.getOrElse("")}""",
+        content = Text(label)
     ),
     hint = if (hint.isDefined) {
         Some(Hint(

--- a/app/views/playComponents/input_yes_no_with_text_expander.scala.html
+++ b/app/views/playComponents/input_yes_no_with_text_expander.scala.html
@@ -20,7 +20,7 @@
     govukErrorSummary : GovukErrorSummary
 )
 @(
-    label: Html,
+    label: String,
     textLabel: String,
     hint: Option[String] = None,
     textHintLine1: Option[String] = None,
@@ -57,14 +57,13 @@
     fieldset = Some(Fieldset(
         legend = Some(Legend(
             classes = labelClass.getOrElse("govuk-fieldset__legend--xl"),
-            content = HtmlContent(label),
+            content = Text(label),
             isPageHeading = false,
         ))
     )),
     hint = hint.map(hintString => Hint(content = Text(hintString))),
     items = Seq("yes", "no").map(answer =>
         RadioItem(value = Some((answer == "yes").toString),
-            id = Some(s"${yesNoField.name}-$answer"),
             content = Text(messages(s"site.$answer")),
             conditionalHtml = if(answer == "yes") Some(textHtml) else None
         ))

--- a/app/views/removeOtherSelectedOption.scala.html
+++ b/app/views/removeOtherSelectedOption.scala.html
@@ -21,7 +21,7 @@
     formWithCSRF: FormWithCSRF,
     errorSummary: playComponents.error_summary,
     inputYesOrNo: playComponents.input_yes_no,
-    heading: hmrcPageHeading,
+    heading: playComponents.headingWithCaption,
     submitButton: playComponents.submit_button
 )
 
@@ -48,10 +48,8 @@
 
         @errorSummary(form.errors)
 
-        @heading(PageHeading(
-            text = messages("RemoveOtherSelectedOption.heading", messages(collectionId)),
-            section = Some(messages("site.service_name.with_tax_year", taxYear.asString))
-        ))
+        @heading(heading = messages("RemoveOtherSelectedOption.heading", messages(collectionId)),
+            taxYear = Some(taxYear.asString))
 
         @inputYesOrNo(
             isPageHeading = false,

--- a/app/views/selectBenefits.scala.html
+++ b/app/views/selectBenefits.scala.html
@@ -23,7 +23,7 @@
     formWithCSRF: FormWithCSRF,
     layout: Layout,
     errorSummary: playComponents.error_summary,
-    heading: playComponents.heading,
+    heading: playComponents.headingWithCaption,
     inputCheckBox: playComponents.input_check_box,
     submitButton: playComponents.submit_button
 )
@@ -56,7 +56,7 @@
         @inputCheckBox(
             viewModel = InputViewModel("value", form),
             legend = messages("selectBenefits.heading", taxYear.asString),
-            legendClass = Some("visually-hidden"),
+            legendClass = Some("govuk-visually-hidden"),
             inputs = Benefits.sortedBenefits.map { checkboxOption =>
                 CheckboxItem(
                     content = HtmlContent(messages(s"selectBenefits.$checkboxOption")),

--- a/app/views/selectCompanyBenefits.scala.html
+++ b/app/views/selectCompanyBenefits.scala.html
@@ -22,7 +22,7 @@
     formWithCSRF: FormWithCSRF,
     layout: Layout,
     errorSummary: playComponents.error_summary,
-    heading: playComponents.heading,
+    caption: playComponents.caption,
     inputCheckbox: playComponents.input_check_box,
     submitButton: playComponents.submit_button
 )
@@ -48,12 +48,11 @@
 
         @errorSummary(form.errors)
 
-        @heading(messages("selectCompanyBenefits.heading"), taxYear = Some(taxYear.asString))
+        @caption(taxYear = Some(taxYear.asString))
 
         @inputCheckbox(
             viewModel = InputViewModel("value", form),
             legend = messages("selectCompanyBenefits.heading", taxYear.asString),
-            legendClass = Some("visually-hidden"),
             inputs = CompanyBenefits.sortedCompanyBenefits.map { checkboxOption =>
                 CheckboxItem(
                     content = HtmlContent(messages(s"selectCompanyBenefits.$checkboxOption")),

--- a/app/views/selectTaxYear.scala.html
+++ b/app/views/selectTaxYear.scala.html
@@ -55,7 +55,6 @@
             legendClass = None,
             inputs = SelectTaxYear.options map { radioOption =>
                 RadioItem(
-                    id = Some(radioOption.id),
                     value = Some(radioOption.value),
                     content = HtmlContent(radioOption.message.html)
                 )

--- a/app/views/selectTaxableIncome.scala.html
+++ b/app/views/selectTaxableIncome.scala.html
@@ -23,7 +23,7 @@
         formWithCSRF: FormWithCSRF,
         layout: Layout,
         errorSummary: playComponents.error_summary,
-        heading: playComponents.heading,
+        heading: playComponents.headingWithCaption,
         inputCheckBox: playComponents.input_check_box,
         submitButton: playComponents.submit_button
 )
@@ -51,12 +51,13 @@
 
             @errorSummary(form.errors)
 
-            @heading(messages("selectBenefits.heading"), taxYear = Some(taxYear.asString))
+            @heading(messages("selectTaxableIncome.heading"), taxYear = Some(taxYear.asString))
 
             @inputCheckBox(
+                isPageHeading = false,
                 viewModel = InputViewModel("value", form),
                 legend = messages("selectTaxableIncome.heading", taxYear.asString),
-                legendClass = Some("visually-hidden"),
+                legendClass = Some("govuk-visually-hidden"),
                 inputs = SelectTaxableIncomeForm.options.map { checkboxOption =>
                     CheckboxItem(
                         content = HtmlContent(messages(checkboxOption._1).capitalize),

--- a/app/views/sessionTimedout.scala.html
+++ b/app/views/sessionTimedout.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = messages("timedOut.title")){
 
-    <h1 class="govuk-heading-xl">@messages("timedOut.heading")</h1>
+    @heading(messages("timedOut.heading"))
 
     <p class="govuk-body">@messages("timedOut.message")</p>
 

--- a/app/views/telephoneNumber.scala.html
+++ b/app/views/telephoneNumber.scala.html
@@ -46,10 +46,11 @@
     @formWithCSRF(action = TelephoneNumberController.onSubmit(mode), 'autoComplete -> "off") {
 
         @errorSummary(form.errors)
-
+        @headingWithCaption(messages("telephoneNumber.heading"), taxYear = Some(taxYear.asString))
         @inputYesNoWithTextExpander(
             hint = Some(messages("telephoneNumber.hintPara1")),
-            label = headingWithCaption(messages("telephoneNumber.heading"), taxYear = Some(taxYear.asString)),
+            label = messages("telephoneNumber.heading"),
+            labelClass = Some("govuk-visually-hidden"),
             textLabel = messages("telephoneNumber.telephoneNumberField"),
             inputType = "tel",
             autoComplete = true,

--- a/app/views/whereToSendPayment.scala.html
+++ b/app/views/whereToSendPayment.scala.html
@@ -51,7 +51,6 @@
                 legendClass = Some("visually-hidden"),
                 inputs = (WhereToSendPaymentForm.options map { radioOption =>
                     RadioItem(
-                        id = Some(radioOption.id),
                         value = Some(radioOption.value),
                         content = HtmlContent(radioOption.message.html)
                     )

--- a/test/utils/CascadeUpsertSpec.scala
+++ b/test/utils/CascadeUpsertSpec.scala
@@ -267,33 +267,33 @@ class CascadeUpsertSpec extends SpecBase with ScalaCheckPropertyChecks {
   "SelectTaxYear" must {
     "clear employment details if selectTaxYear has changed" in {
       val originalCacheMap = new CacheMap(id = "test", Map(
-        SelectTaxYearId.toString -> Json.toJson("current-year-minus-3"),
+        SelectTaxYearId.toString -> Json.toJson("value-3"),
         EmploymentDetailsId.toString -> Json.toJson(true),
         EnterPayeReferenceId.toString -> Json.toJson("123/AB456"),
         DetailsOfEmploymentOrPensionId.toString -> Json.toJson("value")
       ))
 
       val cascadeUpsert = new CascadeUpsert
-      val result = cascadeUpsert("selectTaxYear", Json.toJson("current-year-minus-2"), originalCacheMap)
+      val result = cascadeUpsert("selectTaxYear", Json.toJson("value-2"), originalCacheMap)
 
       result.data mustBe Map(
-        SelectTaxYearId.toString -> Json.toJson("current-year-minus-2")
+        SelectTaxYearId.toString -> Json.toJson("value-2")
       )
     }
 
     "change nothing if selectTaxYear is the same" in {
       val originalCacheMap = new CacheMap(id = "test", Map(
-        SelectTaxYearId.toString -> Json.toJson("current-year-minus-2"),
+        SelectTaxYearId.toString -> Json.toJson("value-2"),
         EmploymentDetailsId.toString -> Json.toJson(true),
         EnterPayeReferenceId.toString -> Json.toJson("123/AB456"),
         DetailsOfEmploymentOrPensionId.toString -> Json.toJson("value")
       ))
 
       val cascadeUpsert = new CascadeUpsert
-      val result = cascadeUpsert("selectTaxYear", Json.toJson("current-year-minus-2"), originalCacheMap)
+      val result = cascadeUpsert("selectTaxYear", Json.toJson("value-2"), originalCacheMap)
 
       result.data mustBe Map(
-        SelectTaxYearId.toString -> Json.toJson("current-year-minus-2"),
+        SelectTaxYearId.toString -> Json.toJson("value-2"),
         EmploymentDetailsId.toString -> Json.toJson(true),
         EnterPayeReferenceId.toString -> Json.toJson("123/AB456"),
         DetailsOfEmploymentOrPensionId.toString -> Json.toJson("value")

--- a/test/utils/CheckYourAnswersHelperSpec.scala
+++ b/test/utils/CheckYourAnswersHelperSpec.scala
@@ -533,7 +533,7 @@ class CheckYourAnswersHelperSpec extends SpecBase with MockitoSugar with BeforeA
       when(answers.anyAgentRef) thenReturn Some(AnyAgentRef.Yes(agentRef))
 
       helper.anyAgentRef.get.label.key mustBe messages("anyAgentRef.heading", "Test name")
-      helper.anyAgentRef.get.url mustBe Some(routes.AnyAgentRefController.onPageLoad(CheckMode).url + "/#anyAgentRef-yes")
+      helper.anyAgentRef.get.url mustBe Some(routes.AnyAgentRefController.onPageLoad(CheckMode).url + "/#anyAgentRef")
       helper.anyAgentRef.get.answer.key mustBe yes
       helper.agentReferenceNumber.get.label.key mustBe "anyAgentRef.agentRefField"
       helper.agentReferenceNumber.get.url mustBe Some(routes.AnyAgentRefController.onPageLoad(CheckMode).url + "/#agentRef")
@@ -591,7 +591,7 @@ class CheckYourAnswersHelperSpec extends SpecBase with MockitoSugar with BeforeA
       val telNo = "0191123123"
       when(answers.anyTelephoneNumber) thenReturn Some(TelephoneOption.Yes(telNo))
       helper.anyTelephoneNumber.get.label.key mustBe "telephoneNumber.heading"
-      helper.anyTelephoneNumber.get.url mustBe Some(routes.TelephoneNumberController.onPageLoad(CheckMode).url + "/#anyTelephoneNumber-yes")
+      helper.anyTelephoneNumber.get.url mustBe Some(routes.TelephoneNumberController.onPageLoad(CheckMode).url + "/#anyTelephoneNumber")
       helper.telephoneNumber.get.label.key mustBe "telephoneNumber.telephoneNumberField"
       helper.telephoneNumber.get.url mustBe Some(routes.TelephoneNumberController.onPageLoad(CheckMode).url + "/#telephoneNumber")
       helper.anyTelephoneNumber.get.answer.key mustBe yes

--- a/test/utils/CheckYourAnswersSectionsSpec.scala
+++ b/test/utils/CheckYourAnswersSectionsSpec.scala
@@ -128,25 +128,25 @@ class CheckYourAnswersSectionsSpec extends SpecBase with MockitoSugar with Befor
 
       rows(2).label.key mustBe "howMuchBankInterest.heading"
       rows(3).label.key mustBe "anyTaxableBankInterestOption.checkYourAnswersLabel"
-      rows(3).url mustBe Some(routes.AnyTaxableBankInterestController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+      rows(3).url mustBe Some(routes.AnyTaxableBankInterestController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
       rows(4).label.key mustBe "anyTaxableBankInterest.checkYourAnswersLabel"
       rows(4).url mustBe Some(routes.AnyTaxableBankInterestController.onPageLoad(CheckMode).url + "/#taxPaidAmount")
 
       rows(5).label.key mustBe "howMuchForeignIncome.heading"
       rows(6).label.key mustBe "anyTaxableForeignIncomeOption.checkYourAnswersLabel"
-      rows(6).url mustBe Some(routes.AnyTaxableForeignIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+      rows(6).url mustBe Some(routes.AnyTaxableForeignIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
       rows(7).label.key mustBe "anyTaxableForeignIncome.checkYourAnswersLabel"
       rows(7).url mustBe Some(routes.AnyTaxableForeignIncomeController.onPageLoad(CheckMode).url + "/#taxPaidAmount")
 
       rows(8).label.key mustBe "howMuchInvestmentOrDividend.heading"
       rows(9).label.key mustBe "anyTaxableInvestmentsOption.checkYourAnswersLabel"
-      rows(9).url mustBe Some(routes.AnyTaxableInvestmentsController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+      rows(9).url mustBe Some(routes.AnyTaxableInvestmentsController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
       rows(10).label.key mustBe "anyTaxableInvestments.checkYourAnswersLabel"
       rows(10).url mustBe Some(routes.AnyTaxableInvestmentsController.onPageLoad(CheckMode).url + "/#taxPaidAmount")
 
       rows(11).label.key mustBe "howMuchRentalIncome.heading"
       rows(12).label.key mustBe "anyTaxableRentalIncomeOption.checkYourAnswersLabel"
-      rows(12).url mustBe Some(routes.AnyTaxableRentalIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid-yes")
+      rows(12).url mustBe Some(routes.AnyTaxableRentalIncomeController.onPageLoad(CheckMode).url + "/#anyTaxPaid")
       rows(13).label.key mustBe "anyTaxableRentalIncome.checkYourAnswersLabel"
       rows(13).url mustBe Some(routes.AnyTaxableRentalIncomeController.onPageLoad(CheckMode).url + "/#taxPaidAmount")
 

--- a/test/views/AnyAgentRefViewSpec.scala
+++ b/test/views/AnyAgentRefViewSpec.scala
@@ -93,15 +93,15 @@ class AnyAgentRefViewSpec extends NewQuestionViewBehaviours[AnyAgentRef] with Gu
 
           "contain an input for the value" in {
             val doc = asDocument(createView(form))
-            assertRenderedById(doc, "anyAgentRef-yes")
-            assertRenderedById(doc, "anyAgentRef-no")
+            assertRenderedById(doc, "anyAgentRef")
+            assertRenderedById(doc, "anyAgentRef-2")
             assertRenderedById(doc, "agentRef")
           }
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyAgentRef-yes").hasAttr("checked"))
-            assert(!doc.getElementById("anyAgentRef-no").hasAttr("checked"))
+            assert(!doc.getElementById("anyAgentRef").hasAttr("checked"))
+            assert(!doc.getElementById("anyAgentRef-2").hasAttr("checked"))
           }
 
 
@@ -144,14 +144,14 @@ class AnyAgentRefViewSpec extends NewQuestionViewBehaviours[AnyAgentRef] with Gu
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(AnyAgentRef.Yes(testAgentRef))))
-        assert(doc.getElementById("anyAgentRef-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyAgentRef-no").hasAttr("checked"))
+        assert(doc.getElementById("anyAgentRef").hasAttr("checked"))
+        assert(!doc.getElementById("anyAgentRef-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(AnyAgentRef.No)))
-        assert(!doc.getElementById("anyAgentRef-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyAgentRef-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyAgentRef").hasAttr("checked"))
+        assert(doc.getElementById("anyAgentRef-2").hasAttr("checked"))
       }
 
 

--- a/test/views/AnyTaxableBankInterestViewSpec.scala
+++ b/test/views/AnyTaxableBankInterestViewSpec.scala
@@ -91,15 +91,15 @@ class AnyTaxableBankInterestViewSpec extends NewQuestionViewBehaviours[AnyTaxPai
 
           "contain an input for the value" in {
             val doc = asDocument(createView(form))
-            assertRenderedById(doc, "anyTaxPaid-no")
-            assertRenderedById(doc, "anyTaxPaid-yes")
+            assertRenderedById(doc, "anyTaxPaid-2")
+            assertRenderedById(doc, "anyTaxPaid")
             assertRenderedById(doc, "taxPaidAmount")
           }
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-            assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
           }
 
           "include the form's value in the value input" in {
@@ -141,14 +141,14 @@ class AnyTaxableBankInterestViewSpec extends NewQuestionViewBehaviours[AnyTaxPai
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.Yes(testAmount))))
-        assert(doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.No)))
-        assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "not render an error summary" in {

--- a/test/views/AnyTaxableForeignIncomeViewSpec.scala
+++ b/test/views/AnyTaxableForeignIncomeViewSpec.scala
@@ -91,15 +91,15 @@ class AnyTaxableForeignIncomeViewSpec extends NewQuestionViewBehaviours[AnyTaxPa
 
           "contain an input for the value" in {
             val doc = asDocument(createView(form))
-            assertRenderedById(doc, "anyTaxPaid-no")
-            assertRenderedById(doc, "anyTaxPaid-yes")
+            assertRenderedById(doc, "anyTaxPaid-2")
+            assertRenderedById(doc, "anyTaxPaid")
             assertRenderedById(doc, "taxPaidAmount")
           }
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-            assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
           }
 
           "include the form's value in the value input" in {
@@ -141,14 +141,14 @@ class AnyTaxableForeignIncomeViewSpec extends NewQuestionViewBehaviours[AnyTaxPa
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.Yes(testAmount))))
-        assert(doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.No)))
-        assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "not render an error summary" in {

--- a/test/views/AnyTaxableInvestmentsViewSpec.scala
+++ b/test/views/AnyTaxableInvestmentsViewSpec.scala
@@ -91,15 +91,15 @@ class AnyTaxableInvestmentsViewSpec extends NewQuestionViewBehaviours[AnyTaxPaid
 
           "contain an input for the value" in {
             val doc = asDocument(createView(form))
-            assertRenderedById(doc, "anyTaxPaid-no")
-            assertRenderedById(doc, "anyTaxPaid-yes")
+            assertRenderedById(doc, "anyTaxPaid-2")
+            assertRenderedById(doc, "anyTaxPaid")
             assertRenderedById(doc, "taxPaidAmount")
           }
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-            assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
           }
 
           "include the form's value in the value input" in {
@@ -141,14 +141,14 @@ class AnyTaxableInvestmentsViewSpec extends NewQuestionViewBehaviours[AnyTaxPaid
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.Yes(testAmount))))
-        assert(doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.No)))
-        assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "not render an error summary" in {

--- a/test/views/AnyTaxableOtherIncomeViewSpec.scala
+++ b/test/views/AnyTaxableOtherIncomeViewSpec.scala
@@ -93,15 +93,15 @@ class AnyTaxableOtherIncomeViewSpec extends NewQuestionViewBehaviours[AnyTaxPaid
 
           "contain an input for the value" in {
             val doc = asDocument(createView(form))
-            assertRenderedById(doc, "anyTaxPaid-no")
-            assertRenderedById(doc, "anyTaxPaid-yes")
+            assertRenderedById(doc, "anyTaxPaid-2")
+            assertRenderedById(doc, "anyTaxPaid")
             assertRenderedById(doc, "taxPaidAmount")
           }
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-            assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
           }
 
           "include the form's value in the value input" in {
@@ -143,14 +143,14 @@ class AnyTaxableOtherIncomeViewSpec extends NewQuestionViewBehaviours[AnyTaxPaid
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.Yes(testAmount))))
-        assert(doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.No)))
-        assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "not render an error summary" in {

--- a/test/views/AnyTaxableRentalIncomeViewSpec.scala
+++ b/test/views/AnyTaxableRentalIncomeViewSpec.scala
@@ -91,15 +91,15 @@ class AnyTaxableRentalIncomeViewSpec extends NewQuestionViewBehaviours[AnyTaxPai
 
           "contain an input for the value" in {
             val doc = asDocument(createView(form))
-            assertRenderedById(doc, "anyTaxPaid-no")
-            assertRenderedById(doc, "anyTaxPaid-yes")
+            assertRenderedById(doc, "anyTaxPaid-2")
+            assertRenderedById(doc, "anyTaxPaid")
             assertRenderedById(doc, "taxPaidAmount")
           }
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-            assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+            assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
           }
 
           "include the form's value in the value input" in {
@@ -141,14 +141,14 @@ class AnyTaxableRentalIncomeViewSpec extends NewQuestionViewBehaviours[AnyTaxPai
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.Yes(testAmount))))
-        assert(doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(AnyTaxPaid.No)))
-        assert(!doc.getElementById("anyTaxPaid-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyTaxPaid-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyTaxPaid").hasAttr("checked"))
+        assert(doc.getElementById("anyTaxPaid-2").hasAttr("checked"))
       }
 
       "not render an error summary" in {

--- a/test/views/ConfirmationViewSpec.scala
+++ b/test/views/ConfirmationViewSpec.scala
@@ -20,10 +20,10 @@ import org.jsoup.select.NodeFilter
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.twirl.api.HtmlFormat
-import views.behaviours.ViewBehaviours
+import views.behaviours.{NewViewBehaviours, ViewBehaviours}
 import views.html.confirmation
 
-class ConfirmationViewSpec extends ViewBehaviours with MockitoSugar with GuiceOneAppPerSuite {
+class ConfirmationViewSpec extends NewViewBehaviours with MockitoSugar with GuiceOneAppPerSuite {
 
   private val messageKeyPrefix = "confirmation"
   private val submissionReference = " ABC-1234-DEF"  //this contains normal hyphens

--- a/test/views/SelectBenefitsViewSpec.scala
+++ b/test/views/SelectBenefitsViewSpec.scala
@@ -22,10 +22,10 @@ import models.{Benefits, NormalMode}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import play.twirl.api.Html
-import views.behaviours.{NewCheckboxViewBehaviours, ViewBehaviours}
+import views.behaviours.{NewCheckboxViewBehaviours, NewViewBehaviours, ViewBehaviours}
 import views.html.selectBenefits
 
-class SelectBenefitsViewSpec extends ViewBehaviours with NewCheckboxViewBehaviours[Benefits.Value] with GuiceOneAppPerSuite {
+class SelectBenefitsViewSpec extends NewViewBehaviours with NewCheckboxViewBehaviours[Benefits.Value] with GuiceOneAppPerSuite {
 
   val messageKeyPrefix = "selectBenefits"
   val fieldKey = "value"

--- a/test/views/SelectCompanyBenefitsViewSpec.scala
+++ b/test/views/SelectCompanyBenefitsViewSpec.scala
@@ -22,10 +22,10 @@ import models.{CompanyBenefits, NormalMode}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import play.twirl.api.Html
-import views.behaviours.{NewCheckboxViewBehaviours, ViewBehaviours}
+import views.behaviours.{NewCheckboxViewBehaviours, NewViewBehaviours}
 import views.html.selectCompanyBenefits
 
-class SelectCompanyBenefitsViewSpec extends ViewBehaviours with NewCheckboxViewBehaviours[CompanyBenefits.Value] with GuiceOneAppPerSuite {
+class SelectCompanyBenefitsViewSpec extends NewViewBehaviours with NewCheckboxViewBehaviours[CompanyBenefits.Value] with GuiceOneAppPerSuite {
 
   val messageKeyPrefix = "selectCompanyBenefits"
   val fieldKey = "value"

--- a/test/views/SelectTaxYearViewSpec.scala
+++ b/test/views/SelectTaxYearViewSpec.scala
@@ -21,10 +21,10 @@ import models.{NormalMode, SelectTaxYear}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import utils.RadioOption
-import views.behaviours.ViewBehaviours
+import views.behaviours.NewViewBehaviours
 import views.html.selectTaxYear
 
-class SelectTaxYearViewSpec extends ViewBehaviours with GuiceOneAppPerSuite {
+class SelectTaxYearViewSpec extends NewViewBehaviours with GuiceOneAppPerSuite {
 
   private val messageKeyPrefix = "selectTaxYear"
   private val selectTaxYear: selectTaxYear = fakeApplication.injector.instanceOf[selectTaxYear]

--- a/test/views/SelectTaxableIncomeViewSpec.scala
+++ b/test/views/SelectTaxableIncomeViewSpec.scala
@@ -22,10 +22,10 @@ import models.{NormalMode, TaxableIncome}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.Form
 import play.twirl.api.Html
-import views.behaviours.{NewCheckboxViewBehaviours, ViewBehaviours}
+import views.behaviours.{NewCheckboxViewBehaviours, NewViewBehaviours, ViewBehaviours}
 import views.html.selectTaxableIncome
 
-class SelectTaxableIncomeViewSpec extends ViewBehaviours with NewCheckboxViewBehaviours[TaxableIncome.Value] with GuiceOneAppPerSuite {
+class SelectTaxableIncomeViewSpec extends NewViewBehaviours with NewCheckboxViewBehaviours[TaxableIncome.Value] with GuiceOneAppPerSuite {
 
   val messageKeyPrefix = "selectTaxableIncome"
   val fieldKey = "value"

--- a/test/views/SessionExpiredViewSpec.scala
+++ b/test/views/SessionExpiredViewSpec.scala
@@ -17,10 +17,10 @@
 package views
 
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import views.behaviours.ViewBehaviours
+import views.behaviours.{NewViewBehaviours, ViewBehaviours}
 import views.html.session_expired
 
-class SessionExpiredViewSpec extends ViewBehaviours with GuiceOneAppPerSuite {
+class SessionExpiredViewSpec extends NewViewBehaviours with GuiceOneAppPerSuite {
 
   val sessionExpired: session_expired = fakeApplication.injector.instanceOf[session_expired]
 

--- a/test/views/TelephoneNumberViewSpec.scala
+++ b/test/views/TelephoneNumberViewSpec.scala
@@ -95,8 +95,8 @@ class TelephoneNumberViewSpec extends NewQuestionViewBehaviours[TelephoneOption]
           "contain 2 radioButtons" in {
             val doc = asDocument(createView(form))
             assert(doc.select("input[type=\"radio\"]").size == 2)
-            assertRenderedById(doc, "anyTelephoneNumber-no")
-            assertRenderedById(doc, "anyTelephoneNumber-yes")
+            assertRenderedById(doc, "anyTelephoneNumber-2")
+            assertRenderedById(doc, "anyTelephoneNumber")
           }
 
           "contain a conditionally-revealing text input" which {
@@ -115,8 +115,8 @@ class TelephoneNumberViewSpec extends NewQuestionViewBehaviours[TelephoneOption]
 
           "have no values checked when rendered with no form" in {
             val doc = asDocument(createView(form))
-            assert(!doc.getElementById("anyTelephoneNumber-no").hasAttr("checked"))
-            assert(!doc.getElementById("anyTelephoneNumber-yes").hasAttr("checked"))
+            assert(!doc.getElementById("anyTelephoneNumber-2").hasAttr("checked"))
+            assert(!doc.getElementById("anyTelephoneNumber").hasAttr("checked"))
           }
 
 
@@ -159,14 +159,14 @@ class TelephoneNumberViewSpec extends NewQuestionViewBehaviours[TelephoneOption]
 
       "have only the correct value checked when yes selected" in {
         val doc = asDocument(createView(form.fill(TelephoneOption.Yes(testPhoneNumber))))
-        assert(doc.getElementById("anyTelephoneNumber-yes").hasAttr("checked"))
-        assert(!doc.getElementById("anyTelephoneNumber-no").hasAttr("checked"))
+        assert(doc.getElementById("anyTelephoneNumber").hasAttr("checked"))
+        assert(!doc.getElementById("anyTelephoneNumber-2").hasAttr("checked"))
       }
 
       "have only the correct value checked when no selected" in {
         val doc = asDocument(createView(form.fill(TelephoneOption.No)))
-        assert(!doc.getElementById("anyTelephoneNumber-yes").hasAttr("checked"))
-        assert(doc.getElementById("anyTelephoneNumber-no").hasAttr("checked"))
+        assert(!doc.getElementById("anyTelephoneNumber").hasAttr("checked"))
+        assert(doc.getElementById("anyTelephoneNumber-2").hasAttr("checked"))
       }
 
       "not render an error summary" in {

--- a/test/views/behaviours/NewCheckboxViewBehaviours.scala
+++ b/test/views/behaviours/NewCheckboxViewBehaviours.scala
@@ -18,9 +18,9 @@ package views.behaviours
 
 import play.api.data.{Form, FormError}
 import play.twirl.api.Html
-import views.ViewSpecBase
+import views.{NewViewSpecBase, ViewSpecBase}
 
-trait NewCheckboxViewBehaviours[A] extends ViewSpecBase {
+trait NewCheckboxViewBehaviours[A] extends NewViewSpecBase {
 
   def form: Form[Seq[A]]
   def createView(form: Form[Seq[A]]): Html

--- a/test/views/behaviours/QuestionViewBehaviours.scala
+++ b/test/views/behaviours/QuestionViewBehaviours.scala
@@ -19,7 +19,7 @@ package views.behaviours
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
 
-trait QuestionViewBehaviours[A] extends ViewBehaviours {
+trait QuestionViewBehaviours[A] extends NewViewBehaviours {
 
   val errorKey = "value"
   val errorMessage = "error.number"


### PR DESCRIPTION
# DL-6208 - H1 Header spacing changes

- some unit tests were still using the old helpers, changed them to new migration ones
- text-expander error messages didn't link to input fields when a radio button was unselected, amended ids
- removed hmrcPageHeading and replaced with components for headings and captions
- changed component labels to strings, as play-frontend wraps the content in a h1 which caused spacing issues

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
