### PR TITLE
DL-6351 Unauthorised error template new UI components

### DIFF
--- a/app/views/unauthorised_error_template.scala.html
+++ b/app/views/unauthorised_error_template.scala.html
@@ -16,14 +16,27 @@
 
 @import config.FrontendAppConfig
 
-@this()
+@this(
+    layout: Layout
+)
 
-@(pageTitle: String, heading: String, message: String, appConfig: FrontendAppConfig)(implicit messages: Messages, request: Request[_])
+@(
+    pageTitle: String,
+    heading: String,
+    message: String,
+    appConfig: FrontendAppConfig
+)(implicit messages: Messages, request: Request[_])
 
-@contentHeader = {
-<h1>@heading</h1>
+@layout(
+    pageTitle = pageTitle,
+    timeoutEnabled = false,
+    backLinkEnabled = false,
+    accountMenuEnabled = false
+) {
+
+ <h1 class="govuk-heading-xl">@heading</h1>
+
+ <p class="govuk-body">@message</p>
+
 }
 
-@mainContent = {
-<p>@message</p>
-}

--- a/conf/messages
+++ b/conf/messages
@@ -543,3 +543,7 @@ accessibility.subheading09 = Non-compliance with the accessibility regulations
 accessibility.par24.before = The service was built using parts that were tested by the
 accessibility.par24.linkText = Digital Accessibility Centre
 accessibility.par24.after = The full service was tested by HMRC and included disabled users
+
+global.error.InternalServerError500.title=Sorry, we are experiencing technical difficulties - 500
+global.error.InternalServerError500.heading=Sorry, we’re experiencing technical difficulties
+global.error.InternalServerError500.message=Please try again in a few minutes.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -607,3 +607,7 @@ accessibility.subheading09 = Diffyg cydymffurfio â rheoliadau hygyrchedd
 accessibility.par24.before = Adeiladwyd y gwasanaeth gan ddefnyddio rhannau a brofwyd gan y
 accessibility.par24.linkText = Ganolfan Hygyrchedd Digidol (Digital Accessibility Centre)
 accessibility.par24.after = Profwyd y gwasanaeth llawn gan CThEM, ac roedd y gwaith o brofi’r gwasanaeth yn cynnwys defnyddwyr anabl
+
+global.error.InternalServerError500.title=Mae''n ddrwg gennym, rydym yn profi anawsterau technegol – 500
+global.error.InternalServerError500.heading=Mae''n ddrwg gennym, rydym yn profi anawsterau technegol
+global.error.InternalServerError500.message=Rhowch gynnig arall arni mewn ychydig o funudau.


### PR DESCRIPTION
DL-6351

Moving **unauthorised_error_template** to new UI components to prevent it showing a blank screen

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
